### PR TITLE
Add basic travis setup

### DIFF
--- a/build/.travis.yml
+++ b/build/.travis.yml
@@ -10,7 +10,8 @@ os:
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+
 
 script:
+  - cmake ..
   - make

--- a/build/.travis.yml
+++ b/build/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+os:
+  - linux
+  - osx
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake ..
+
+script:
+  - make


### PR DESCRIPTION
Add a basic travis setup to distopia. I don't have permissions to actually hook up travis itself. @richardjgowers  you might have to do this.

Fixes #8 