### PR TITLE
example clang-format

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -85,7 +85,7 @@ IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentWidth:     4
+IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -16,8 +16,8 @@ AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true

--- a/src/compare/vanilla.cpp
+++ b/src/compare/vanilla.cpp
@@ -4,35 +4,29 @@
 
 #include <math.h>
 
-void VanillaCalcBonds(const float* coords1,
-                      const float* coords2,
-                      const float* box,
-                      unsigned int nvals,
-                      float* output) {
-    for (unsigned int i=0; i<nvals; ++i) {
-        float r2 = 0.0;
-        for (unsigned char j=0; j<3; ++j) {
-            float rij = coords1[i * 3 + j] - coords2[i * 3 + j];
-            float adj = round(rij / box[j]);
-            rij -= adj * box[j];
+void VanillaCalcBonds(const float* coords1, const float* coords2,
+                      const float* box, unsigned int nvals, float* output) {
+  for (unsigned int i = 0; i < nvals; ++i) {
+    float r2 = 0.0;
+    for (unsigned char j = 0; j < 3; ++j) {
+      float rij = coords1[i * 3 + j] - coords2[i * 3 + j];
+      float adj = round(rij / box[j]);
+      rij -= adj * box[j];
 
-            r2 += rij * rij;
-        }
-        *output++ = sqrtf(r2);
+      r2 += rij * rij;
     }
+    *output++ = sqrtf(r2);
+  }
 }
 
-void VanillaCalcBondsIdx(const float* coords,
-                         const unsigned int* idx,
-                         const float* box,
-                         unsigned int nvals,
-                         float* output) {
-  for (unsigned int i=0; i<nvals; ++i) {
-    unsigned int a = idx[i*2];
-    unsigned int b = idx[i*2 + 1];
+void VanillaCalcBondsIdx(const float* coords, const unsigned int* idx,
+                         const float* box, unsigned int nvals, float* output) {
+  for (unsigned int i = 0; i < nvals; ++i) {
+    unsigned int a = idx[i * 2];
+    unsigned int b = idx[i * 2 + 1];
     float r2 = 0.0;
-    for (unsigned char j=0; j<3; ++j) {
-      float rij = coords[a*3 + j] - coords[b*3 + j];
+    for (unsigned char j = 0; j < 3; ++j) {
+      float rij = coords[a * 3 + j] - coords[b * 3 + j];
       float adj = round(rij / box[j]);
       rij -= adj * box[j];
 

--- a/src/lib/src/distopia.cpp
+++ b/src/lib/src/distopia.cpp
@@ -3,29 +3,28 @@
 //
 
 #include <immintrin.h>
-#include <iostream>
 #include <math.h>
 
+#include <iostream>
 
 // [X1, Y1, Z1, X2], [Y2, Z2, X3, Y3], [Z3, X4, Y4, Z4]
 // TO
 // [X1, X2, X3, X4], [Y1, Y2, Y3, Y4], [Z1, Z2, Z3, Z4]
-#define AoS2SoA(v1, v2, v3) \
-do {\
-  __m128 tmp1, tmp2; \
-  tmp1 = _mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 2, 1)); \
-  tmp2 = _mm_shuffle_ps(v2, v3, _MM_SHUFFLE(2, 1, 3, 2)); \
-  (v1) = _mm_shuffle_ps(v1, tmp2, _MM_SHUFFLE(2, 0, 3, 0)); \
-  (v2) = _mm_shuffle_ps(tmp1, tmp2, _MM_SHUFFLE(3, 1, 2, 0)); \
-  (v3) = _mm_shuffle_ps(tmp1, v3, _MM_SHUFFLE(3, 0, 3, 1)); \
-} while (0)
+#define AoS2SoA(v1, v2, v3)                                     \
+  do {                                                          \
+    __m128 tmp1, tmp2;                                          \
+    tmp1 = _mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 2, 1));     \
+    tmp2 = _mm_shuffle_ps(v2, v3, _MM_SHUFFLE(2, 1, 3, 2));     \
+    (v1) = _mm_shuffle_ps(v1, tmp2, _MM_SHUFFLE(2, 0, 3, 0));   \
+    (v2) = _mm_shuffle_ps(tmp1, tmp2, _MM_SHUFFLE(3, 1, 2, 0)); \
+    (v3) = _mm_shuffle_ps(tmp1, v3, _MM_SHUFFLE(3, 0, 3, 1));   \
+  } while (0)
 
-inline float SinglePairwiseDistance(const float* coords1,
-                                    const float* coords2,
+inline float SinglePairwiseDistance(const float* coords1, const float* coords2,
                                     const float* box) {
   float dx = 0.0;
 
-  for (unsigned char i=0; i<3; ++i) {
+  for (unsigned char i = 0; i < 3; ++i) {
     float rij = coords1[i] - coords2[i];
     float adj = round(rij / box[i]);
     rij -= adj * box[i];
@@ -34,148 +33,154 @@ inline float SinglePairwiseDistance(const float* coords1,
   return sqrtf(dx);
 }
 
-// zip over coords1 and coords2 and calculate pairwise distance w/ periodic boundary conditions
-// store results in output, must be large enough etc etc
-void CalcBondsOrtho(const float* coords1,
-                    const float* coords2,
-                    const float* box,
-                    unsigned int nvals,
-                    float* output) {
+// zip over coords1 and coords2 and calculate pairwise distance w/ periodic
+// boundary conditions store results in output, must be large enough etc etc
+void CalcBondsOrtho(const float* coords1, const float* coords2,
+                    const float* box, unsigned int nvals, float* output) {
   __m128 Xb1, Xb2, Xb3;
   __m128 ib1, ib2, ib3;  // inverse box lengths
   Xb1 = _mm_set_ps1(box[0]);
   Xb2 = _mm_set_ps1(box[1]);
   Xb3 = _mm_set_ps1(box[2]);
-  ib1 = _mm_set_ps1(1/box[0]);
-  ib2 = _mm_set_ps1(1/box[1]);
-  ib3 = _mm_set_ps1(1/box[2]);
+  ib1 = _mm_set_ps1(1 / box[0]);
+  ib2 = _mm_set_ps1(1 / box[1]);
+  ib3 = _mm_set_ps1(1 / box[2]);
 
-    // deal with single iterations
-    unsigned int nsingle = nvals & 0x03;
-    for (unsigned char i=0; i<nsingle; ++i)
-      *output++ = SinglePairwiseDistance(coords1 + i, coords2 + i, box);
+  // deal with single iterations
+  unsigned int nsingle = nvals & 0x03;
+  for (unsigned char i = 0; i < nsingle; ++i)
+    *output++ = SinglePairwiseDistance(coords1 + i, coords2 + i, box);
 
-    coords1 += nsingle*3;
-    coords2 += nsingle*3;
+  coords1 += nsingle * 3;
+  coords2 += nsingle * 3;
 
-    unsigned int niters = nvals >> 2;
-    for (unsigned int i=0; i<niters; ++i) {
-      // load 4 coords from each
-      __m128 p1, p2, p3, p4, p5, p6;
-      p1 = _mm_loadu_ps(coords1 + i*12);
-      p2 = _mm_loadu_ps(coords1 + i*12 + 4);
-      p3 = _mm_loadu_ps(coords1 + i*12 + 8);
-      p4 = _mm_loadu_ps(coords2 + i*12);
-      p5 = _mm_loadu_ps(coords2 + i*12 + 4);
-      p6 = _mm_loadu_ps(coords2 + i*12 + 8);
+  unsigned int niters = nvals >> 2;
+  for (unsigned int i = 0; i < niters; ++i) {
+    // load 4 coords from each
+    __m128 p1, p2, p3, p4, p5, p6;
+    p1 = _mm_loadu_ps(coords1 + i * 12);
+    p2 = _mm_loadu_ps(coords1 + i * 12 + 4);
+    p3 = _mm_loadu_ps(coords1 + i * 12 + 8);
+    p4 = _mm_loadu_ps(coords2 + i * 12);
+    p5 = _mm_loadu_ps(coords2 + i * 12 + 4);
+    p6 = _mm_loadu_ps(coords2 + i * 12 + 8);
 
-      // TODO: Can push the conversion to only the deltas (i.e. only one conversion needed)
-      AoS2SoA(p1, p2, p3);
-      AoS2SoA(p4, p5, p6);
+    // TODO: Can push the conversion to only the deltas (i.e. only one
+    // conversion needed)
+    AoS2SoA(p1, p2, p3);
+    AoS2SoA(p4, p5, p6);
 
-      // calculate deltas
-      p1 = _mm_sub_ps(p1, p4);  // dx
-      p2 = _mm_sub_ps(p2, p5);  // dy
-      p3 = _mm_sub_ps(p3, p6);  // dz
+    // calculate deltas
+    p1 = _mm_sub_ps(p1, p4);  // dx
+    p2 = _mm_sub_ps(p2, p5);  // dy
+    p3 = _mm_sub_ps(p3, p6);  // dz
 
-      // apply periodic boundary conditions
-      // rij = rij - box * rint(rij / box)
-      __m128 adj1, adj2, adj3;
-      adj1 = _mm_mul_ps(Xb1, _mm_round_ps(_mm_mul_ps(p1, ib1), (_MM_ROUND_NEAREST|_MM_FROUND_NO_EXC)));
-      adj2 = _mm_mul_ps(Xb2, _mm_round_ps(_mm_mul_ps(p2, ib2), (_MM_ROUND_NEAREST|_MM_FROUND_NO_EXC)));
-      adj3 = _mm_mul_ps(Xb3, _mm_round_ps(_mm_mul_ps(p3, ib3), (_MM_ROUND_NEAREST|_MM_FROUND_NO_EXC)));
+    // apply periodic boundary conditions
+    // rij = rij - box * rint(rij / box)
+    __m128 adj1, adj2, adj3;
+    adj1 =
+        _mm_mul_ps(Xb1, _mm_round_ps(_mm_mul_ps(p1, ib1),
+                                     (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
+    adj2 =
+        _mm_mul_ps(Xb2, _mm_round_ps(_mm_mul_ps(p2, ib2),
+                                     (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
+    adj3 =
+        _mm_mul_ps(Xb3, _mm_round_ps(_mm_mul_ps(p3, ib3),
+                                     (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
 
-      p1 = _mm_sub_ps(p1, adj1);
-      p2 = _mm_sub_ps(p2, adj2);
-      p3 = _mm_sub_ps(p3, adj3);
+    p1 = _mm_sub_ps(p1, adj1);
+    p2 = _mm_sub_ps(p2, adj2);
+    p3 = _mm_sub_ps(p3, adj3);
 
-      // square each
-      p1 = _mm_mul_ps(p1, p1);
-      p2 = _mm_mul_ps(p2, p2);
-      p3 = _mm_mul_ps(p3, p3);
+    // square each
+    p1 = _mm_mul_ps(p1, p1);
+    p2 = _mm_mul_ps(p2, p2);
+    p3 = _mm_mul_ps(p3, p3);
 
-      // summation time
-      __m128 rsq = _mm_add_ps(p1, _mm_add_ps(p2, p3));
-      __m128 r = _mm_sqrt_ps(rsq);
+    // summation time
+    __m128 rsq = _mm_add_ps(p1, _mm_add_ps(p2, p3));
+    __m128 r = _mm_sqrt_ps(rsq);
 
-      _mm_storeu_ps(output, r);
-      output += 4;
-    }
+    _mm_storeu_ps(output, r);
+    output += 4;
+  }
 }
 
-// identical to _MM_TRANSPOSE4_ps except we don't care about the last column in input, i.e. final row in output
+// identical to _MM_TRANSPOSE4_ps except we don't care about the last column in
+// input, i.e. final row in output
 #define _MM_TRANSPOSE(row0, row1, row2, row3) \
-do { \
-  __m128 tmp3, tmp2, tmp1, tmp0; \
-  tmp0 = _mm_unpacklo_ps((row0), (row1)); \
-  tmp2 = _mm_unpacklo_ps((row2), (row3)); \
-  tmp1 = _mm_unpackhi_ps((row0), (row1)); \
-  tmp3 = _mm_unpackhi_ps((row2), (row3)); \
-  (row0) = _mm_movelh_ps(tmp0, tmp2); \
-  (row1) = _mm_movehl_ps(tmp2, tmp0); \
-  (row2) = _mm_movelh_ps(tmp1, tmp3); \
-} while (0)
-  //  (row3) = _mm_movehl_ps(tmp3, tmp1);
+  do {                                        \
+    __m128 tmp3, tmp2, tmp1, tmp0;            \
+    tmp0 = _mm_unpacklo_ps((row0), (row1));   \
+    tmp2 = _mm_unpacklo_ps((row2), (row3));   \
+    tmp1 = _mm_unpackhi_ps((row0), (row1));   \
+    tmp3 = _mm_unpackhi_ps((row2), (row3));   \
+    (row0) = _mm_movelh_ps(tmp0, tmp2);       \
+    (row1) = _mm_movehl_ps(tmp2, tmp0);       \
+    (row2) = _mm_movelh_ps(tmp1, tmp3);       \
+  } while (0)
+//  (row3) = _mm_movehl_ps(tmp3, tmp1);
 
 // Safely load 3 coordinates into Xregister
-// If final coordinate, load starting at previous value (i.e. Z component of penultimate) and shunt backwards
-#define SAFEREAD(beg, end, idx, Xreg)    \
-do {                                     \
-  if (beg + idx + 4 < end)               \
-    Xreg = _mm_loadu_ps(beg + idx);      \
-  else {                                 \
-    Xreg = _mm_loadu_ps(beg + idx - 1);  \
-    _mm_permute_ps(Xreg, _MM_PERM_ADCB); \
-  }                                      \
-} while (0)
+// If final coordinate, load starting at previous value (i.e. Z component of
+// penultimate) and shunt backwards
+#define SAFEREAD(beg, end, idx, Xreg)      \
+  do {                                     \
+    if (beg + idx + 4 < end)               \
+      Xreg = _mm_loadu_ps(beg + idx);      \
+    else {                                 \
+      Xreg = _mm_loadu_ps(beg + idx - 1);  \
+      _mm_permute_ps(Xreg, _MM_PERM_ADCB); \
+    }                                      \
+  } while (0)
 
-// Read *Ncoords* pairs of indices from idx and calculate pairwise distance betwixt
-void CalcBondsIdxOrtho(const float* coords,
-                       const float* coords_end,
+// Read *Ncoords* pairs of indices from idx and calculate pairwise distance
+// betwixt
+void CalcBondsIdxOrtho(const float* coords, const float* coords_end,
                        const unsigned int* idx,  // holds [[1, 2], [7, 8], etc]
-                       const float* box,
-                       unsigned int Ncoords,
-                       float* output) {
+                       const float* box, unsigned int Ncoords, float* output) {
   __m128 xbox[3], ib[3];
-  for (unsigned char i=0; i<3; ++i) {
+  for (unsigned char i = 0; i < 3; ++i) {
     // b[0] = [lx, lx, lx, lx], ib == inverse box
     xbox[i] = _mm_set_ps1(box[i]);
     ib[i] = _mm_set_ps1(1 / box[i]);
   }
 
   unsigned int nsingle = Ncoords & 0x03;
-  for (unsigned char ix=0; ix<nsingle; ++ix) {
-    unsigned int i = *(idx + ix*2);
-    unsigned int j = *(idx + ix*2 + 1);
-    *output++ = SinglePairwiseDistance(coords + i*3, coords + j*3, box);
+  for (unsigned char ix = 0; ix < nsingle; ++ix) {
+    unsigned int i = *(idx + ix * 2);
+    unsigned int j = *(idx + ix * 2 + 1);
+    *output++ = SinglePairwiseDistance(coords + i * 3, coords + j * 3, box);
   }
   idx += nsingle * 2;
 
   unsigned int niters = Ncoords >> 2;
-  for (unsigned int i=0; i<niters; ++i) {
+  for (unsigned int i = 0; i < niters; ++i) {
     __m128 p1[4];
     __m128 p2[4];
-    for (unsigned char j=0; j<4; ++j) {
-      unsigned int a = idx[i*8 + j*2];
-      unsigned int b = idx[i*8 + j*2 + 1];
-      SAFEREAD(coords, coords_end, a*3, p1[j]);
-      SAFEREAD(coords, coords_end, b*3, p2[j]);
+    for (unsigned char j = 0; j < 4; ++j) {
+      unsigned int a = idx[i * 8 + j * 2];
+      unsigned int b = idx[i * 8 + j * 2 + 1];
+      SAFEREAD(coords, coords_end, a * 3, p1[j]);
+      SAFEREAD(coords, coords_end, b * 3, p2[j]);
     }
     _MM_TRANSPOSE(p1[0], p1[1], p1[2], p1[3]);
     _MM_TRANSPOSE(p2[0], p2[1], p2[2], p2[3]);
     // p1[0] x coordinate of each, 1=y, 2=z, p1[3] now meaningless
     __m128 delta[3];
-    for (unsigned char j=0; j<3; ++j)
+    for (unsigned char j = 0; j < 3; ++j) {
       delta[j] = _mm_sub_ps(p1[j], p2[j]);
-
+    }
     // apply minimum image convention
-    for (unsigned char j=0; j<3; ++j) {
-      __m128 adj = _mm_mul_ps(xbox[j], _mm_round_ps(_mm_mul_ps(delta[j], ib[j]), (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
+    for (unsigned char j = 0; j < 3; ++j) {
+      __m128 adj = _mm_mul_ps(
+          xbox[j], _mm_round_ps(_mm_mul_ps(delta[j], ib[j]),
+                                (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
       delta[j] = _mm_sub_ps(delta[j], adj);
     }
 
     // square each and sum
-    for (unsigned char j=0; j<3; ++j)
+    for (unsigned char j = 0; j < 3; ++j)
       delta[j] = _mm_mul_ps(delta[j], delta[j]);
     delta[0] = _mm_add_ps(delta[0], delta[1]);
     delta[0] = _mm_add_ps(delta[0], delta[2]);
@@ -187,35 +192,31 @@ void CalcBondsIdxOrtho(const float* coords,
   }
 }
 
-
-void DistanceArrayOrtho(const float* coords1,
-                        const float* coords2,
-                        const float* box,
-                        unsigned int ncoords1,
-                        unsigned int ncoords2,
-                        float* output) {
+void DistanceArrayOrtho(const float* coords1, const float* coords2,
+                        const float* box, unsigned int ncoords1,
+                        unsigned int ncoords2, float* output) {
   __m128 xbox[3], ib[3];
-  for (unsigned char i=0; i<3; ++i) {
+  for (unsigned char i = 0; i < 3; ++i) {
     // b[0] = [lx, lx, lx, lx], ib == inverse box
     xbox[i] = _mm_set_ps1(box[i]);
     ib[i] = _mm_set_ps1(1 / box[i]);
   }
 
-  for (unsigned int i=0; i<ncoords1; ++i) {
+  for (unsigned int i = 0; i < ncoords1; ++i) {
     // single iterations of j
     unsigned int nsingle = ncoords2 & 0x03;
-    for (unsigned int j=0; j<nsingle; ++j) {
-      *output++ = SinglePairwiseDistance(coords1 + i*3, coords2 + j*3, box);
+    for (unsigned int j = 0; j < nsingle; ++j) {
+      *output++ = SinglePairwiseDistance(coords1 + i * 3, coords2 + j * 3, box);
     }
 
     // broadcast i coordinate into 3 registers
     __m128 icoord[3];
-    icoord[0] = _mm_set1_ps(*(coords1 + i*3));
-    icoord[1] = _mm_set1_ps(*(coords1 + i*3 + 1));
-    icoord[2] = _mm_set1_ps(*(coords1 + i*3 + 2));
+    icoord[0] = _mm_set1_ps(*(coords1 + i * 3));
+    icoord[1] = _mm_set1_ps(*(coords1 + i * 3 + 1));
+    icoord[2] = _mm_set1_ps(*(coords1 + i * 3 + 2));
 
     unsigned int niters = ncoords2 >> 2;
-    for (unsigned int j=0; j<niters; ++j) {
+    for (unsigned int j = 0; j < niters; ++j) {
       __m128 jcoord[3];
       // load 12 bytes (4 coordinates) in
       jcoord[0] = _mm_loadu_ps(coords2 + nsingle * 3 + j * 12);
@@ -225,19 +226,21 @@ void DistanceArrayOrtho(const float* coords1,
       AoS2SoA(jcoord[0], jcoord[1], jcoord[2]);
 
       __m128 delta[3];
-      for (unsigned char x=0; x<3; ++x)
+      for (unsigned char x = 0; x < 3; ++x) {
         delta[x] = _mm_sub_ps(icoord[x], jcoord[x]);
-
+      }
       // apply minimum image convention
-      for (unsigned char x=0; x<3; ++x) {
-        __m128 adj = _mm_mul_ps(xbox[x],
-                                _mm_round_ps(_mm_mul_ps(delta[x], ib[x]), (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
+      for (unsigned char x = 0; x < 3; ++x) {
+        __m128 adj = _mm_mul_ps(
+            xbox[x], _mm_round_ps(_mm_mul_ps(delta[x], ib[x]),
+                                  (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
         delta[x] = _mm_sub_ps(delta[x], adj);
       }
 
       // square each and sum
-      for (unsigned char x=0; x<3; ++x)
+      for (unsigned char x = 0; x < 3; ++x) {
         delta[x] = _mm_mul_ps(delta[x], delta[x]);
+      }
       delta[0] = _mm_add_ps(delta[0], delta[1]);
       delta[0] = _mm_add_ps(delta[0], delta[2]);
 
@@ -249,58 +252,56 @@ void DistanceArrayOrtho(const float* coords1,
   }
 }
 
-void DistanceArrayIdxOrtho(const float* coords,
-                           const float* coords_end,
-                           const unsigned int* idx1,  // array of indices within coords
-                           const unsigned int* idx2,
-                           const float* box,
-                           unsigned int ncoords1,
-                           unsigned int ncoords2,
-                           float* output) {
+void DistanceArrayIdxOrtho(
+    const float* coords, const float* coords_end,
+    const unsigned int* idx1,  // array of indices within coords
+    const unsigned int* idx2, const float* box, unsigned int ncoords1,
+    unsigned int ncoords2, float* output) {
   __m128 xbox[3], ib[3];
-  for (unsigned char i=0; i<3; ++i) {
+  for (unsigned char i = 0; i < 3; ++i) {
     // b[0] = [lx, lx, lx, lx], ib == inverse box
     xbox[i] = _mm_set_ps1(box[i]);
     ib[i] = _mm_set_ps1(1 / box[i]);
   }
 
-  for (unsigned int ix=0; ix<ncoords1; ++ix) {
+  for (unsigned int ix = 0; ix < ncoords1; ++ix) {
     unsigned int i = *(idx1 + ix);
     // single iterations of j
     unsigned int nsingle = ncoords2 & 0x03;
-    for (unsigned int jx=0; jx<nsingle; ++jx) {
+    for (unsigned int jx = 0; jx < nsingle; ++jx) {
       unsigned int j = *(idx2 + jx);
-      *output++ = SinglePairwiseDistance(coords + i*3, coords + j*3, box);
+      *output++ = SinglePairwiseDistance(coords + i * 3, coords + j * 3, box);
     }
 
     // broadcast i coordinate into 3 registers
     __m128 icoord[3];
-    icoord[0] = _mm_set1_ps(*(coords + i*3));
-    icoord[1] = _mm_set1_ps(*(coords + i*3 + 1));
-    icoord[2] = _mm_set1_ps(*(coords + i*3 + 2));
+    icoord[0] = _mm_set1_ps(*(coords + i * 3));
+    icoord[1] = _mm_set1_ps(*(coords + i * 3 + 1));
+    icoord[2] = _mm_set1_ps(*(coords + i * 3 + 2));
 
     unsigned int niters = ncoords2 >> 2;
-    for (unsigned int jx=0; jx<niters; ++jx) {
+    for (unsigned int jx = 0; jx < niters; ++jx) {
       __m128 jcoord[4];
-      for (unsigned char kx=0; kx<4; ++kx) {
-        unsigned int k = *(idx2 + nsingle*3 + jx*4 + kx);
-        SAFEREAD(coords, coords_end, k*3, jcoord[kx]);
+      for (unsigned char kx = 0; kx < 4; ++kx) {
+        unsigned int k = *(idx2 + nsingle * 3 + jx * 4 + kx);
+        SAFEREAD(coords, coords_end, k * 3, jcoord[kx]);
       }
       _MM_TRANSPOSE(jcoord[0], jcoord[1], jcoord[2], jcoord[3]);
 
       __m128 delta[3];
-      for (unsigned char x=0; x<3; ++x)
+      for (unsigned char x = 0; x < 3; ++x)
         delta[x] = _mm_sub_ps(icoord[x], jcoord[x]);
 
       // apply minimum image convention
-      for (unsigned char x=0; x<3; ++x) {
-        __m128 adj = _mm_mul_ps(xbox[x],
-                                _mm_round_ps(_mm_mul_ps(delta[x], ib[x]), (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
+      for (unsigned char x = 0; x < 3; ++x) {
+        __m128 adj = _mm_mul_ps(
+            xbox[x], _mm_round_ps(_mm_mul_ps(delta[x], ib[x]),
+                                  (_MM_ROUND_NEAREST | _MM_FROUND_NO_EXC)));
         delta[x] = _mm_sub_ps(delta[x], adj);
       }
 
       // square each and sum
-      for (unsigned char x=0; x<3; ++x)
+      for (unsigned char x = 0; x < 3; ++x)
         delta[x] = _mm_mul_ps(delta[x], delta[x]);
       delta[0] = _mm_add_ps(delta[0], delta[1]);
       delta[0] = _mm_add_ps(delta[0], delta[2]);

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -15,13 +15,17 @@ bool loadHeader(FILE* fp, int* Ncoords, float* box) {
   // boxx, boxy, boxz
   char tmp[1024];
 
-  if (!fgets(tmp, 1024, fp)) abort();
+  if (!fgets(tmp, 1024, fp)) {
+    abort();
+  }
 
   *Ncoords = strtol(tmp, NULL, 10);
 
   fgets(tmp, 1024, fp);
   char* next = tmp;
-  for (unsigned i = 0; i < 3; ++i) *box++ = strtof(next, &next);
+  for (unsigned i = 0; i < 3; ++i) {
+    *box++ = strtof(next, &next);
+  }
 
   return true;
 }
@@ -32,7 +36,9 @@ bool loadCoords(FILE* fp, int Ncoords, float* coords) {
   for (unsigned int i = 0; i < Ncoords; ++i) {
     fgets(tmp, 4096, fp);
     char* next = tmp;
-    for (unsigned char j = 0; j < 3; ++j) *coords++ = strtof(next, &next);
+    for (unsigned char j = 0; j < 3; ++j) {
+      *coords++ = strtof(next, &next);
+    }
   }
 
   return true;
@@ -40,8 +46,11 @@ bool loadCoords(FILE* fp, int Ncoords, float* coords) {
 
 #define TOL 0.0001
 static bool verify(const float* ref, const float* other, unsigned int Ncoords) {
-  for (unsigned int i = 0; i < Ncoords; ++i)
-    if (fabs(ref[i] - other[i]) > TOL) return false;
+  for (unsigned int i = 0; i < Ncoords; ++i) {
+    if (fabs(ref[i] - other[i]) > TOL) {
+      return false;
+    }
+  }
   return true;
 }
 
@@ -61,8 +70,12 @@ int main(int argc, char* argv[]) {
   int Ncoords = 0;
 
   FILE* fp = fopen(fname, "r");
-  if (!fp) return 1;
-  if (!loadHeader(fp, &Ncoords, box)) return 2;
+  if (!fp) {
+    return 1;
+  }
+  if (!loadHeader(fp, &Ncoords, box)) {
+    return 2;
+  }
 
   coords = (float*)malloc(Ncoords * 3 * sizeof(float));
   results = (float*)malloc(Ncoords * sizeof(float) / 2);
@@ -101,11 +114,11 @@ int main(int argc, char* argv[]) {
 
   std::cout << "XMM calc_bonds:     " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
+  if (!verify(ref_results, results, Nresults)) {
     std::cout << "XMM result wrong!\n";
-  else
+  } else {
     std::cout << "XMM Results verified\n";
-
+  }
   t1 = std::chrono::steady_clock::now();
 
   _calc_bond_distance_ortho((coordinate*)coords1, (coordinate*)coords2,
@@ -117,11 +130,11 @@ int main(int argc, char* argv[]) {
 
   std::cout << "MDA calc_bonds:     " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
+  if (!verify(ref_results, results, Nresults)) {
     std::cout << "MDA result wrong!\n";
-  else
+  } else {
     std::cout << "MDA Results verified\n";
-
+  }
   t1 = std::chrono::steady_clock::now();
 
   dist_mic(coords1, coords2, box, results, Nresults);
@@ -132,10 +145,10 @@ int main(int argc, char* argv[]) {
 
   std::cout << "MDtraj calc_bonds:  " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
+  if (!verify(ref_results, results, Nresults)) {
     std::cout << "MDtraj result wrong!\n";
-  else
+  } else {
     std::cout << "MDtraj Results verified\n";
-
+  }
   return 0;
 }

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -1,144 +1,141 @@
-#include <iostream>
 #include <math.h>
-#include <chrono>
 #include <memory.h>
 
-#include "distopia.h"  // a fancy approach
-#include "vanilla.h"  // a naive approach
-#include "calc_distances.h"  // from mdanalysis
+#include <chrono>
+#include <iostream>
+
+#include "calc_distances.h"   // from mdanalysis
 #include "distancekernels.h"  // from mdtraj
+#include "distopia.h"         // a fancy approach
+#include "vanilla.h"          // a naive approach
 
 bool loadHeader(FILE* fp, int* Ncoords, float* box) {
-  // header format:
-  // natoms
-  // boxx, boxy, boxz
-  char tmp[1024];
+    // header format:
+    // natoms
+    // boxx, boxy, boxz
+    char tmp[1024];
 
-  if (!fgets(tmp, 1024, fp))
-    abort();
+    if (!fgets(tmp, 1024, fp)) abort();
 
-  *Ncoords = strtol(tmp, NULL, 10);
+    *Ncoords = strtol(tmp, NULL, 10);
 
-  fgets(tmp, 1024, fp);
-  char* next = tmp;
-  for (unsigned i=0; i<3; ++i)
-    *box++ = strtof(next, &next);
+    fgets(tmp, 1024, fp);
+    char* next = tmp;
+    for (unsigned i = 0; i < 3; ++i) *box++ = strtof(next, &next);
 
-  return true;
+    return true;
 }
 
 bool loadCoords(FILE* fp, int Ncoords, float* coords) {
-  char tmp[4096];
+    char tmp[4096];
 
-  for (unsigned int i=0; i<Ncoords; ++i) {
-    fgets(tmp, 4096, fp);
-    char* next = tmp;
-    for (unsigned char j=0; j<3; ++j)
-      *coords++ = strtof(next, &next);
-  }
+    for (unsigned int i = 0; i < Ncoords; ++i) {
+        fgets(tmp, 4096, fp);
+        char* next = tmp;
+        for (unsigned char j = 0; j < 3; ++j) *coords++ = strtof(next, &next);
+    }
 
-  return true;
+    return true;
 }
 
 #define TOL 0.0001
 static bool verify(const float* ref, const float* other, unsigned int Ncoords) {
-  for (unsigned int i=0; i<Ncoords; ++i)
-    if (fabs(ref[i] - other[i]) > TOL)
-      return false;
-  return true;
+    for (unsigned int i = 0; i < Ncoords; ++i)
+        if (fabs(ref[i] - other[i]) > TOL) return false;
+    return true;
 }
 
 int main(int argc, char* argv[]) {
-  // usage: file.in
-  if (argc <=1) {
-    printf("Too few arguments, please supply a coordinate file as a command line argument.\n");
-    return(0);
-  }
-  char* fname = argv[1];
+    // usage: file.in
+    if (argc <= 1) {
+        printf(
+            "Too few arguments, please supply a coordinate file as a command "
+            "line "
+            "argument.\n");
+        return (0);
+    }
+    char* fname = argv[1];
 
-  float box[3];
-  float *coords, *coords1, *coords2, *results;
-  int Ncoords=0;
+    float box[3];
+    float *coords, *coords1, *coords2, *results;
+    int Ncoords = 0;
 
-  FILE* fp = fopen(fname, "r");
-  if (!fp)
-      return 1;
-   if(!loadHeader(fp, &Ncoords, box))
-       return 2;
+    FILE* fp = fopen(fname, "r");
+    if (!fp) return 1;
+    if (!loadHeader(fp, &Ncoords, box)) return 2;
 
-  coords = (float*) malloc(Ncoords * 3 * sizeof(float));
-  results = (float*) malloc(Ncoords * sizeof(float) /2);
+    coords = (float*)malloc(Ncoords * 3 * sizeof(float));
+    results = (float*)malloc(Ncoords * sizeof(float) / 2);
 
-  loadCoords(fp, Ncoords, coords);
+    loadCoords(fp, Ncoords, coords);
 
-  std::cout << "Read " << Ncoords << " coordinates \n";
+    std::cout << "Read " << Ncoords << " coordinates \n";
 
-  // split coordinates in half
-  coords1 = coords;
-  coords2 = coords + (3*Ncoords/2);
-  int Nresults = Ncoords/2;
+    // split coordinates in half
+    coords1 = coords;
+    coords2 = coords + (3 * Ncoords / 2);
+    int Nresults = Ncoords / 2;
 
-  std::chrono::steady_clock::time_point t1, t2;
-  std::chrono::duration<double> dt;
+    std::chrono::steady_clock::time_point t1, t2;
+    std::chrono::duration<double> dt;
 
-  t1 = std::chrono::steady_clock::now();
+    t1 = std::chrono::steady_clock::now();
 
-  VanillaCalcBonds(coords1, coords2, box, Nresults, results);
+    VanillaCalcBonds(coords1, coords2, box, Nresults, results);
 
-  t2 = std::chrono::steady_clock::now();
+    t2 = std::chrono::steady_clock::now();
 
-  dt = (t2 - t1);
-  std::cout << "Regular calc_bonds: " << dt.count() << "\n";
+    dt = (t2 - t1);
+    std::cout << "Regular calc_bonds: " << dt.count() << "\n";
 
-  float* ref_results = (float*) malloc(sizeof(float) * Nresults);
-  memcpy(ref_results, results, sizeof(float) * Nresults);
+    float* ref_results = (float*)malloc(sizeof(float) * Nresults);
+    memcpy(ref_results, results, sizeof(float) * Nresults);
 
-  t1 = std::chrono::steady_clock::now();
+    t1 = std::chrono::steady_clock::now();
 
-  CalcBondsOrtho(coords1, coords2, box, Nresults, results);
+    CalcBondsOrtho(coords1, coords2, box, Nresults, results);
 
-  t2 = std::chrono::steady_clock::now();
+    t2 = std::chrono::steady_clock::now();
 
-  dt = (t2 - t1);
+    dt = (t2 - t1);
 
-  std::cout << "XMM calc_bonds:     " << dt.count() << "\n";
+    std::cout << "XMM calc_bonds:     " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
-    std::cout << "XMM result wrong!\n";
-  else
-    std::cout << "XMM Results verified\n";
+    if (!verify(ref_results, results, Nresults))
+        std::cout << "XMM result wrong!\n";
+    else
+        std::cout << "XMM Results verified\n";
 
-  t1 = std::chrono::steady_clock::now();
+    t1 = std::chrono::steady_clock::now();
 
-  _calc_bond_distance_ortho((coordinate*)coords1,
-                            (coordinate*)coords2, Nresults, box, results);
+    _calc_bond_distance_ortho((coordinate*)coords1, (coordinate*)coords2,
+                              Nresults, box, results);
 
-  t2 = std::chrono::steady_clock::now();
+    t2 = std::chrono::steady_clock::now();
 
-  dt = (t2 - t1);
+    dt = (t2 - t1);
 
-  std::cout << "MDA calc_bonds:     " << dt.count() << "\n";
+    std::cout << "MDA calc_bonds:     " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
-    std::cout << "MDA result wrong!\n";
-  else
-    std::cout << "MDA Results verified\n";
+    if (!verify(ref_results, results, Nresults))
+        std::cout << "MDA result wrong!\n";
+    else
+        std::cout << "MDA Results verified\n";
 
-  t1 = std::chrono::steady_clock::now();
+    t1 = std::chrono::steady_clock::now();
 
-  dist_mic(coords1,
-           coords2, box, results, Nresults);
+    dist_mic(coords1, coords2, box, results, Nresults);
 
-  t2 = std::chrono::steady_clock::now();
+    t2 = std::chrono::steady_clock::now();
 
-  dt = (t2 - t1);
+    dt = (t2 - t1);
 
-  std::cout << "MDtraj calc_bonds:  " << dt.count() << "\n";
+    std::cout << "MDtraj calc_bonds:  " << dt.count() << "\n";
 
-  if (!verify(ref_results, results, Nresults))
-    std::cout << "MDtraj result wrong!\n";
-  else
-    std::cout << "MDtraj Results verified\n";
+    if (!verify(ref_results, results, Nresults))
+        std::cout << "MDtraj result wrong!\n";
+    else
+        std::cout << "MDtraj Results verified\n";
 
-  return 0;
+    return 0;
 }

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -10,132 +10,132 @@
 #include "vanilla.h"          // a naive approach
 
 bool loadHeader(FILE* fp, int* Ncoords, float* box) {
-    // header format:
-    // natoms
-    // boxx, boxy, boxz
-    char tmp[1024];
+  // header format:
+  // natoms
+  // boxx, boxy, boxz
+  char tmp[1024];
 
-    if (!fgets(tmp, 1024, fp)) abort();
+  if (!fgets(tmp, 1024, fp)) abort();
 
-    *Ncoords = strtol(tmp, NULL, 10);
+  *Ncoords = strtol(tmp, NULL, 10);
 
-    fgets(tmp, 1024, fp);
-    char* next = tmp;
-    for (unsigned i = 0; i < 3; ++i) *box++ = strtof(next, &next);
+  fgets(tmp, 1024, fp);
+  char* next = tmp;
+  for (unsigned i = 0; i < 3; ++i) *box++ = strtof(next, &next);
 
-    return true;
+  return true;
 }
 
 bool loadCoords(FILE* fp, int Ncoords, float* coords) {
-    char tmp[4096];
+  char tmp[4096];
 
-    for (unsigned int i = 0; i < Ncoords; ++i) {
-        fgets(tmp, 4096, fp);
-        char* next = tmp;
-        for (unsigned char j = 0; j < 3; ++j) *coords++ = strtof(next, &next);
-    }
+  for (unsigned int i = 0; i < Ncoords; ++i) {
+    fgets(tmp, 4096, fp);
+    char* next = tmp;
+    for (unsigned char j = 0; j < 3; ++j) *coords++ = strtof(next, &next);
+  }
 
-    return true;
+  return true;
 }
 
 #define TOL 0.0001
 static bool verify(const float* ref, const float* other, unsigned int Ncoords) {
-    for (unsigned int i = 0; i < Ncoords; ++i)
-        if (fabs(ref[i] - other[i]) > TOL) return false;
-    return true;
+  for (unsigned int i = 0; i < Ncoords; ++i)
+    if (fabs(ref[i] - other[i]) > TOL) return false;
+  return true;
 }
 
 int main(int argc, char* argv[]) {
-    // usage: file.in
-    if (argc <= 1) {
-        printf(
-            "Too few arguments, please supply a coordinate file as a command "
-            "line "
-            "argument.\n");
-        return (0);
-    }
-    char* fname = argv[1];
+  // usage: file.in
+  if (argc <= 1) {
+    printf(
+        "Too few arguments, please supply a coordinate file as a command "
+        "line "
+        "argument.\n");
+    return (0);
+  }
+  char* fname = argv[1];
 
-    float box[3];
-    float *coords, *coords1, *coords2, *results;
-    int Ncoords = 0;
+  float box[3];
+  float *coords, *coords1, *coords2, *results;
+  int Ncoords = 0;
 
-    FILE* fp = fopen(fname, "r");
-    if (!fp) return 1;
-    if (!loadHeader(fp, &Ncoords, box)) return 2;
+  FILE* fp = fopen(fname, "r");
+  if (!fp) return 1;
+  if (!loadHeader(fp, &Ncoords, box)) return 2;
 
-    coords = (float*)malloc(Ncoords * 3 * sizeof(float));
-    results = (float*)malloc(Ncoords * sizeof(float) / 2);
+  coords = (float*)malloc(Ncoords * 3 * sizeof(float));
+  results = (float*)malloc(Ncoords * sizeof(float) / 2);
 
-    loadCoords(fp, Ncoords, coords);
+  loadCoords(fp, Ncoords, coords);
 
-    std::cout << "Read " << Ncoords << " coordinates \n";
+  std::cout << "Read " << Ncoords << " coordinates \n";
 
-    // split coordinates in half
-    coords1 = coords;
-    coords2 = coords + (3 * Ncoords / 2);
-    int Nresults = Ncoords / 2;
+  // split coordinates in half
+  coords1 = coords;
+  coords2 = coords + (3 * Ncoords / 2);
+  int Nresults = Ncoords / 2;
 
-    std::chrono::steady_clock::time_point t1, t2;
-    std::chrono::duration<double> dt;
+  std::chrono::steady_clock::time_point t1, t2;
+  std::chrono::duration<double> dt;
 
-    t1 = std::chrono::steady_clock::now();
+  t1 = std::chrono::steady_clock::now();
 
-    VanillaCalcBonds(coords1, coords2, box, Nresults, results);
+  VanillaCalcBonds(coords1, coords2, box, Nresults, results);
 
-    t2 = std::chrono::steady_clock::now();
+  t2 = std::chrono::steady_clock::now();
 
-    dt = (t2 - t1);
-    std::cout << "Regular calc_bonds: " << dt.count() << "\n";
+  dt = (t2 - t1);
+  std::cout << "Regular calc_bonds: " << dt.count() << "\n";
 
-    float* ref_results = (float*)malloc(sizeof(float) * Nresults);
-    memcpy(ref_results, results, sizeof(float) * Nresults);
+  float* ref_results = (float*)malloc(sizeof(float) * Nresults);
+  memcpy(ref_results, results, sizeof(float) * Nresults);
 
-    t1 = std::chrono::steady_clock::now();
+  t1 = std::chrono::steady_clock::now();
 
-    CalcBondsOrtho(coords1, coords2, box, Nresults, results);
+  CalcBondsOrtho(coords1, coords2, box, Nresults, results);
 
-    t2 = std::chrono::steady_clock::now();
+  t2 = std::chrono::steady_clock::now();
 
-    dt = (t2 - t1);
+  dt = (t2 - t1);
 
-    std::cout << "XMM calc_bonds:     " << dt.count() << "\n";
+  std::cout << "XMM calc_bonds:     " << dt.count() << "\n";
 
-    if (!verify(ref_results, results, Nresults))
-        std::cout << "XMM result wrong!\n";
-    else
-        std::cout << "XMM Results verified\n";
+  if (!verify(ref_results, results, Nresults))
+    std::cout << "XMM result wrong!\n";
+  else
+    std::cout << "XMM Results verified\n";
 
-    t1 = std::chrono::steady_clock::now();
+  t1 = std::chrono::steady_clock::now();
 
-    _calc_bond_distance_ortho((coordinate*)coords1, (coordinate*)coords2,
-                              Nresults, box, results);
+  _calc_bond_distance_ortho((coordinate*)coords1, (coordinate*)coords2,
+                            Nresults, box, results);
 
-    t2 = std::chrono::steady_clock::now();
+  t2 = std::chrono::steady_clock::now();
 
-    dt = (t2 - t1);
+  dt = (t2 - t1);
 
-    std::cout << "MDA calc_bonds:     " << dt.count() << "\n";
+  std::cout << "MDA calc_bonds:     " << dt.count() << "\n";
 
-    if (!verify(ref_results, results, Nresults))
-        std::cout << "MDA result wrong!\n";
-    else
-        std::cout << "MDA Results verified\n";
+  if (!verify(ref_results, results, Nresults))
+    std::cout << "MDA result wrong!\n";
+  else
+    std::cout << "MDA Results verified\n";
 
-    t1 = std::chrono::steady_clock::now();
+  t1 = std::chrono::steady_clock::now();
 
-    dist_mic(coords1, coords2, box, results, Nresults);
+  dist_mic(coords1, coords2, box, results, Nresults);
 
-    t2 = std::chrono::steady_clock::now();
+  t2 = std::chrono::steady_clock::now();
 
-    dt = (t2 - t1);
+  dt = (t2 - t1);
 
-    std::cout << "MDtraj calc_bonds:  " << dt.count() << "\n";
+  std::cout << "MDtraj calc_bonds:  " << dt.count() << "\n";
 
-    if (!verify(ref_results, results, Nresults))
-        std::cout << "MDtraj result wrong!\n";
-    else
-        std::cout << "MDtraj Results verified\n";
+  if (!verify(ref_results, results, Nresults))
+    std::cout << "MDtraj result wrong!\n";
+  else
+    std::cout << "MDtraj Results verified\n";
 
-    return 0;
+  return 0;
 }

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -57,10 +57,8 @@ static bool verify(const float* ref, const float* other, unsigned int Ncoords) {
 int main(int argc, char* argv[]) {
   // usage: file.in
   if (argc <= 1) {
-    printf(
-        "Too few arguments, please supply a coordinate file as a command "
-        "line "
-        "argument.\n");
+    std::cout << "Too few arguments, please supply a coordinate file as a "
+                 "command line argument.\n";
     return (0);
   }
   char* fname = argv[1];


### PR DESCRIPTION
Example of clang-format (cant be bothered with clang-tidy). Can configure indent to be 2 or 4. Its **2** at the moment (ignore my commit message) making the diff more readable