### PR TITLE
Fix idx loader and remove redundant code paths.

### DIFF
--- a/src/lib/include/vector_triple.h
+++ b/src/lib/include/vector_triple.h
@@ -45,53 +45,6 @@ public:
     }
     DeinterleaveIdx(v_arr, this->x, this->y, this->z);
   }
-  // construct by loading discontiguously from an array of ScalarT eg float* or
-  // double* for which the SIMD width is 4 (__m128 and __m256d). The access is
-  // indexed by 4 integers i,j,k,l where each index is the number
-  // of the particle. Assumes the input vector is in AOS format and returns SOA
-  inline VectorTriple(const ScalarT *source, const ScalarT *end, const int i,
-                      const int j, const int k, const int l) {
-    static_assert(ValuesPerPack<VectorT> == 4,
-                  "Cannot use this constructor on a type "
-                  "that does not have a SIMD width of 4");
-    VectorT a = SafeIdxLoad4<VectorT>(source, 3 * i, end);
-    VectorT b = SafeIdxLoad4<VectorT>(source, 3 * j, end);
-    VectorT c = SafeIdxLoad4<VectorT>(source, 3 * k, end);
-    VectorT d = SafeIdxLoad4<VectorT>(source, 3 * l, end);
-    // deinterleave
-    Deinterleave4x3(a, b, c, d, this->x, this->y, this->z);
-  }
-
-  // construct by loading discontiguously from an array of ScalarT eg float* or
-  // double* for which the SIMD width is 8 (__m256). The access is
-  // indexed by 8 integers i,j,k,l,m,n,o,p where each index is the number
-  // of the particle. Assumes the input vector is in AOS format and returns SOA
-  inline VectorTriple(const ScalarT *source, const ScalarT *end, const int i,
-                      const int j, const int k, const int l, const int m,
-                      const int n, const int o, const int p) {
-    static_assert(ValuesPerPack<VectorT> == 8,
-                  "Cannot use this constructor on a type "
-                  "that does not have a SIMD width of 8");
-    // load half width __m128 lanes
-    VectorToLaneT<VectorT> a =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * i, end);
-    VectorToLaneT<VectorT> b =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * j, end);
-    VectorToLaneT<VectorT> c =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * k, end);
-    VectorToLaneT<VectorT> d =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * l, end);
-    VectorToLaneT<VectorT> e =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * m, end);
-    VectorToLaneT<VectorT> f =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * n, end);
-    VectorToLaneT<VectorT> g =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * o, end);
-    VectorToLaneT<VectorT> h =
-        SafeIdxLoad4<VectorToLaneT<VectorT>>(source, 3 * p, end);
-    // deinterleave and combine lanes into full length packed structs
-    Deinterleave8x3(a, b, c, d, e, f, g, h, this->x, this->y, this->z);
-  }
 
   // reload values from a array of ScalarT eg float* or double *.
   inline void load(ScalarT *source) {

--- a/src/lib/include/vector_triple.h
+++ b/src/lib/include/vector_triple.h
@@ -39,11 +39,11 @@ public:
   inline VectorTriple(ScalarT *source, const ScalarT *end,
                       const std::size_t *idxs) {
 
-    VectorT v_arr[ValuesPerPack<VectorT>];
+    VectorToLoadT<VectorT> v_arr[ValuesPerPack<VectorT>];
     for (std::size_t i = 0; i < ValuesPerPack<VectorT>; i++) {
-      v_arr[i] = SafeIdxLoad4<VectorT>(source, 3 * idxs[i], end);
+      v_arr[i] = SafeIdxLoad4<VectorToLoadT<VectorT>>(source, 3 * idxs[i], end);
     }
-    DeinterleaveIdx<VectorT>(v_arr, this->x, this->y, this->z)    ;
+    DeinterleaveIdx(v_arr, this->x, this->y, this->z);
   }
   // construct by loading discontiguously from an array of ScalarT eg float* or
   // double* for which the SIMD width is 4 (__m128 and __m256d). The access is

--- a/src/lib/include/x86_swizzle.h
+++ b/src/lib/include/x86_swizzle.h
@@ -142,29 +142,24 @@ inline void Deinterleave8x3(const __m128 a, const __m128 b, const __m128 c,
 
 // wraps the individual deinterleaves, use of VectorToLoadT is required for
 // __m256 case which takes an array of __m128, instead of the same type.
-template <typename VectorT, EnableIfVector<VectorT> = 0>
-inline void DeinterleaveIdx(const VectorToLoadT<VectorT> *vec_arr, VectorT &x,
-                            VectorT &y, VectorT &z) {}
 
-template <>
-inline void DeinterleaveIdx<__m128, 1>(const __m128 *vec_arr, __m128 &x,
+
+inline void DeinterleaveIdx(const __m128 *vec_arr, __m128 &x,
                                        __m128 &y, __m128 &z) {
   Deinterleave4x3(vec_arr[0], vec_arr[1], vec_arr[2], vec_arr[3], x, y, z);
 }
 
 #ifdef DISTOPIA_X86_AVX
 
-template <>
-inline void DeinterleaveIdx<__m256d, 1>(const __m256d *vec_arr, __m256d &x,
+inline void DeinterleaveIdx(const __m256d *vec_arr, __m256d &x,
                                         __m256d &y, __m256d &z) {
   Deinterleave4x3(vec_arr[0], vec_arr[1], vec_arr[2], vec_arr[3], x, y, z);
 }
 
-template <>
-inline void DeinterleaveIdx<__m256, 1>(const __m128 *vec_arr, __m256 &x,
+inline void DeinterleaveIdx(const __m128 *vec_arr, __m256 &x,
                                        __m256 &y, __m256 &z) {
-  Deinterleave8x3(vec_arr[0], vec_arr[1], vec_arr[2], vec_arr[3], vec_arr[4], vec_arr[5],
-                  vec_arr[6], vec_arr[7], x, y, z);
+  Deinterleave8x3(vec_arr[0], vec_arr[1], vec_arr[2], vec_arr[3], vec_arr[4],
+                  vec_arr[5], vec_arr[6], vec_arr[7], x, y, z);
 }
 
 #endif // DISTOPIA_X86_AVX

--- a/src/lib/tests/tests.cpp
+++ b/src/lib/tests/tests.cpp
@@ -451,7 +451,62 @@ TEST(TestX86SwizzleVec, Float128IdxLoadDeinterleaved) {
   EXPECT_TRUE(z_is_correct);
 }
 
+TEST(TestX86SwizzleVec, Float128IdxLoadArr) {
+  // dummy data with  4x target and 4x incorrect data mixed in
+  // idx positions for correct data 0,2,4,6
+  float xyz[21] = {00.f, 01.f, 02.f, 0.0f, 0.0f, 0.0f, 10.f,
+                   11.f, 12.f, 0.0f, 0.0f, 0.0f, 20.f, 21.f,
+                   22.f, 0.0f, 0.0f, 0.0f, 30.f, 31.f, 32.f};
+
+  __m128 correct_x = _mm_setr_ps(00.f, 10.f, 20.f, 30.f);
+  __m128 correct_y = _mm_setr_ps(01.f, 11.f, 21.f, 31.f);
+  __m128 correct_z = _mm_setr_ps(02.f, 12.f, 22.f, 32.f);
+  // safeload data and transpose
+  float buffer[12];
+  std::size_t idx[4] = {0, 2, 4, 6};
+  VectorTriple<__m128> vt = VectorTriple<__m128>(xyz, xyz + 21, idx);
+  bool x_is_correct =
+      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.x, correct_x)));
+  bool y_is_correct =
+      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.y, correct_y)));
+  bool z_is_correct =
+      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.z, correct_z)));
+  EXPECT_TRUE(x_is_correct);
+  EXPECT_TRUE(y_is_correct);
+  EXPECT_TRUE(z_is_correct);
+}
+
 #ifdef DISTOPIA_X86_AVX
+
+TEST(TestX86SwizzleVec, Float256IdxLoadArr) {
+  // dummy data with 8x target and 4x incorrect data mixed in
+  // idx positions for correct data 0,2,4,6,7,8,9,11
+  float xyz[36] = {00.f, 01.f, 02.f, 0.0f, 0.0f, 0.0f, 10.f, 11.f, 12.f,
+                   0.0f, 0.0f, 0.0f, 20.f, 21.f, 22.f, 0.0f, 0.0f, 0.0f,
+                   30.f, 31.f, 32.f, 40.f, 41.f, 42.f, 50.f, 51.f, 52.f,
+                   60.f, 61.f, 62.f, 0.0f, 0.0f, 0.0f, 70.f, 71.f, 72.f};
+
+  __m256 correct_x =
+      _mm256_setr_ps(00.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f, 70.f);
+  __m256 correct_y =
+      _mm256_setr_ps(01.f, 11.f, 21.f, 31.f, 41.f, 51.f, 61.f, 71.f);
+  __m256 correct_z =
+      _mm256_setr_ps(02.f, 12.f, 22.f, 32.f, 42.f, 52.f, 62.f, 72.f);
+  // safeload data and transpose
+  std::size_t idx[8] = {0, 2, 4, 6, 7, 8, 9, 11};
+  VectorTriple<__m256> vt =
+      VectorTriple<__m256>(xyz, xyz + 36, idx);
+  bool x_is_correct = _mm256_testc_ps(
+      _mm256_setzero_ps(), _mm256_cmp_ps(vt.x, correct_x, _CMP_NEQ_UQ));
+  bool y_is_correct = _mm256_testc_ps(
+      _mm256_setzero_ps(), _mm256_cmp_ps(vt.y, correct_y, _CMP_NEQ_UQ));
+  bool z_is_correct = _mm256_testc_ps(
+      _mm256_setzero_ps(), _mm256_cmp_ps(vt.z, correct_z, _CMP_NEQ_UQ));
+  EXPECT_TRUE(x_is_correct);
+  EXPECT_TRUE(y_is_correct);
+  EXPECT_TRUE(z_is_correct);
+}
+
 
 TEST(TestX86SwizzleVec, Float256IdxLoadDeinterleaved) {
   // dummy data with 8x target and 4x incorrect data mixed in

--- a/src/lib/tests/tests.cpp
+++ b/src/lib/tests/tests.cpp
@@ -439,30 +439,6 @@ TEST(TestX86SwizzleVec, Float128IdxLoadDeinterleaved) {
   __m128 correct_y = _mm_setr_ps(01.f, 11.f, 21.f, 31.f);
   __m128 correct_z = _mm_setr_ps(02.f, 12.f, 22.f, 32.f);
   // safeload data and transpose
-  VectorTriple<__m128> vt = VectorTriple<__m128>(xyz, xyz + 21, 0, 2, 4, 6);
-  bool x_is_correct =
-      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.x, correct_x)));
-  bool y_is_correct =
-      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.y, correct_y)));
-  bool z_is_correct =
-      _mm_test_all_ones(_mm_castps_si128(_mm_cmpeq_ps(vt.z, correct_z)));
-  EXPECT_TRUE(x_is_correct);
-  EXPECT_TRUE(y_is_correct);
-  EXPECT_TRUE(z_is_correct);
-}
-
-TEST(TestX86SwizzleVec, Float128IdxLoadArr) {
-  // dummy data with  4x target and 4x incorrect data mixed in
-  // idx positions for correct data 0,2,4,6
-  float xyz[21] = {00.f, 01.f, 02.f, 0.0f, 0.0f, 0.0f, 10.f,
-                   11.f, 12.f, 0.0f, 0.0f, 0.0f, 20.f, 21.f,
-                   22.f, 0.0f, 0.0f, 0.0f, 30.f, 31.f, 32.f};
-
-  __m128 correct_x = _mm_setr_ps(00.f, 10.f, 20.f, 30.f);
-  __m128 correct_y = _mm_setr_ps(01.f, 11.f, 21.f, 31.f);
-  __m128 correct_z = _mm_setr_ps(02.f, 12.f, 22.f, 32.f);
-  // safeload data and transpose
-  float buffer[12];
   std::size_t idx[4] = {0, 2, 4, 6};
   VectorTriple<__m128> vt = VectorTriple<__m128>(xyz, xyz + 21, idx);
   bool x_is_correct =
@@ -476,36 +452,8 @@ TEST(TestX86SwizzleVec, Float128IdxLoadArr) {
   EXPECT_TRUE(z_is_correct);
 }
 
+
 #ifdef DISTOPIA_X86_AVX
-
-TEST(TestX86SwizzleVec, Float256IdxLoadArr) {
-  // dummy data with 8x target and 4x incorrect data mixed in
-  // idx positions for correct data 0,2,4,6,7,8,9,11
-  float xyz[36] = {00.f, 01.f, 02.f, 0.0f, 0.0f, 0.0f, 10.f, 11.f, 12.f,
-                   0.0f, 0.0f, 0.0f, 20.f, 21.f, 22.f, 0.0f, 0.0f, 0.0f,
-                   30.f, 31.f, 32.f, 40.f, 41.f, 42.f, 50.f, 51.f, 52.f,
-                   60.f, 61.f, 62.f, 0.0f, 0.0f, 0.0f, 70.f, 71.f, 72.f};
-
-  __m256 correct_x =
-      _mm256_setr_ps(00.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f, 70.f);
-  __m256 correct_y =
-      _mm256_setr_ps(01.f, 11.f, 21.f, 31.f, 41.f, 51.f, 61.f, 71.f);
-  __m256 correct_z =
-      _mm256_setr_ps(02.f, 12.f, 22.f, 32.f, 42.f, 52.f, 62.f, 72.f);
-  // safeload data and transpose
-  std::size_t idx[8] = {0, 2, 4, 6, 7, 8, 9, 11};
-  VectorTriple<__m256> vt =
-      VectorTriple<__m256>(xyz, xyz + 36, idx);
-  bool x_is_correct = _mm256_testc_ps(
-      _mm256_setzero_ps(), _mm256_cmp_ps(vt.x, correct_x, _CMP_NEQ_UQ));
-  bool y_is_correct = _mm256_testc_ps(
-      _mm256_setzero_ps(), _mm256_cmp_ps(vt.y, correct_y, _CMP_NEQ_UQ));
-  bool z_is_correct = _mm256_testc_ps(
-      _mm256_setzero_ps(), _mm256_cmp_ps(vt.z, correct_z, _CMP_NEQ_UQ));
-  EXPECT_TRUE(x_is_correct);
-  EXPECT_TRUE(y_is_correct);
-  EXPECT_TRUE(z_is_correct);
-}
 
 
 TEST(TestX86SwizzleVec, Float256IdxLoadDeinterleaved) {
@@ -523,8 +471,9 @@ TEST(TestX86SwizzleVec, Float256IdxLoadDeinterleaved) {
   __m256 correct_z =
       _mm256_setr_ps(02.f, 12.f, 22.f, 32.f, 42.f, 52.f, 62.f, 72.f);
   // safeload data and transpose
+  std::size_t idx[12] = {0, 2, 4, 6, 7, 8, 9, 11};
   VectorTriple<__m256> vt =
-      VectorTriple<__m256>(xyz, xyz + 36, 0, 2, 4, 6, 7, 8, 9, 11);
+      VectorTriple<__m256>(xyz, xyz + 36, idx);
   bool x_is_correct = _mm256_testc_ps(
       _mm256_setzero_ps(), _mm256_cmp_ps(vt.x, correct_x, _CMP_NEQ_UQ));
   bool y_is_correct = _mm256_testc_ps(
@@ -551,7 +500,8 @@ TEST(TestX86SwizzleVec, Double256IdxLoadDeinterleaved) {
   __m256d correct_y = _mm256_setr_pd(01.0, 11.0, 21.0, 31.0);
   __m256d correct_z = _mm256_setr_pd(02.0, 12.0, 22.0, 32.0);
   // safeload data and transpose
-  VectorTriple<__m256d> vt = VectorTriple<__m256d>(xyz, xyz + 21, 0, 2, 4, 6);
+  std::size_t idx[4] = {0, 2, 4, 6};
+  VectorTriple<__m256d> vt = VectorTriple<__m256d>(xyz, xyz + 21, idx);
 
   bool x_is_correct = _mm256_testc_pd(
       _mm256_setzero_pd(), _mm256_cmp_pd(vt.x, correct_x, _CMP_NEQ_UQ));


### PR DESCRIPTION
Fixed the idx loader which was not calling correct deinterleave overload. 
Fixes #59.

I have also removed index (eg i,j,k,l for 4 wide) explicit loaders.