### PR TITLE
Add benchmarks

### DIFF
--- a/src/compare/vanilla.h
+++ b/src/compare/vanilla.h
@@ -6,6 +6,7 @@
 #define XDIST_VANILLA_H
 
 #include <iostream>
+#include <cmath>
 
 template <typename T>
 void VanillaCalcBonds(const T *coords1, const T *coords2, const T *box,
@@ -14,12 +15,12 @@ void VanillaCalcBonds(const T *coords1, const T *coords2, const T *box,
     T r2 = 0.0;
     for (unsigned char j = 0; j < 3; ++j) {
       T rij = coords1[i * 3 + j] - coords2[i * 3 + j];
-      T adj = round(rij / box[j]);
+      T adj = std::round(rij / box[j]);
       rij -= adj * box[j];
 
       r2 += rij * rij;
     }
-    *output++ = sqrt(r2);
+    *output++ = std::sqrt(r2);
   }
 }
 
@@ -32,7 +33,7 @@ void VanillaCalcBondsNoBox(const T *c1, const T *c2, unsigned int nvals,
       T rij = c1[i * 3 + j] - c2[i * 3 + j];
       r2 += rij * rij;
     }
-    *out++ = sqrt(r2);
+    *out++ = std::sqrt(r2);
   }
 }
 template <typename T>
@@ -50,7 +51,7 @@ void VanillaCalcBondsIdx(const T *coords, std::size_t *idx, const T *box,
 
       r2 += rij * rij;
     }
-    *output++ = sqrt(r2);
+    *output++ = std::sqrt(r2);
   }
 }
 

--- a/src/lib/include/distopia_better_distances.h
+++ b/src/lib/include/distopia_better_distances.h
@@ -1,6 +1,8 @@
 #ifndef XDIST_BETTER_DISTOPIA_H
 #define XDIST_BETTER_DISTOPIA_H
 
+#include "arch_config.h"
+
 /*
  * calculates *nvals* pairwise distances between *coords1* and *coords2*
  * *box* is an orthogonal box
@@ -26,7 +28,7 @@ void CalcBondsFMA(const float* coords1,
                     float* output);
 
 
-#if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#ifdef DISTOPIA_X86_AVX 
 /*
  * calculates *nvals* pairwise distances between *coords1* and *coords2*
  * *box* is an orthogonal box
@@ -41,8 +43,7 @@ void CalcBonds256(
     size_t n,
     float *out
 );
-#endif //DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
-
+#endif //
 
 
 #endif //XDIST_BETTER_DISTOPIA_H

--- a/src/lib/include/vector_triple.h
+++ b/src/lib/include/vector_triple.h
@@ -106,6 +106,20 @@ public:
     }
   }
 
+    inline void load(const ScalarT *source) {
+    // TODO constexpr if with CXX17 support
+    if (ValuesPerPack<VectorT> == 1) {
+      x = genericload<VectorT>(source);
+      y = genericload<VectorT>(source + 1);
+      z = genericload<VectorT>(source + 2);
+    } else {
+      auto t1 = genericload<VectorT>(source);
+      auto t2 = genericload<VectorT>(source + ValuesPerPack<VectorT>);
+      auto t3 = genericload<VectorT>(source + ValuesPerPack<VectorT> * 2);
+      Deinterleave3(t1, t2, t3, x, y, z);
+    }
+  }
+
   // construct by loading discontiguously from an array of ScalarT eg float* or
   // double*. Must pass references as deinterleave must happen on x,y and z
   // simultaneously

--- a/src/lib/src/distopia_better_distances.cpp
+++ b/src/lib/src/distopia_better_distances.cpp
@@ -1,5 +1,7 @@
 #include <cmath>
 #include <immintrin.h>
+#include "arch_config.h"
+
 
 // Jakub's NearbyINT based function
 void CalcBondsNINT(const float *coords1, const float *coords2, const float *box,
@@ -33,7 +35,7 @@ void CalcBondsFMA(const float *coords1, const float *coords2, const float *box,
   }
 }
 
-#if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#ifdef DISTOPIA_X86_AVX 
 
 typedef struct {
     __m256 a;
@@ -132,4 +134,4 @@ void CalcBonds256(
     }
 }
 
-#endif //  DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#endif //

--- a/src/lib/src/x86_calcbonds.cpp
+++ b/src/lib/src/x86_calcbonds.cpp
@@ -36,12 +36,12 @@ void CalcBondsInner(const VectorToScalarT<VectorT> *coords0,
                     const VectorToScalarT<VectorT> *box, std::size_t n,
                     VectorToScalarT<VectorT> *out) {
   auto vecbox = BoxT(box);
-  auto c0 = VectorTriple<VectorT>();
-  auto c1 = VectorTriple<VectorT>();
+
   std::size_t i = 0;
   if (n % ValuesPerPack<VectorT>) {
-    c0.load(coords0);
-    c1.load(coords1);
+    auto c0 = VectorTriple<VectorT>(coords0);
+    auto c1 = VectorTriple<VectorT>(coords1);
+
     VectorT result = NewDistance3dWithBoundary(c0, c1, vecbox);
     // TODO constexpr if with CXX17 support
     if (streaming_store) {
@@ -52,8 +52,8 @@ void CalcBondsInner(const VectorToScalarT<VectorT> *coords0,
     i += n % ValuesPerPack<VectorT>;
   }
   for (; i < n; i += ValuesPerPack<VectorT>) {
-    c0.load(&coords0[3 * i]);
-    c1.load(&coords1[3 * i]);
+    auto c0 = VectorTriple<VectorT>(&coords0[3 * i]);
+    auto c1 = VectorTriple<VectorT>(&coords1[3 * i]);
 
     VectorT result = NewDistance3dWithBoundary(c0, c1, vecbox);
     // TODO constexpr if with CXX17 support

--- a/src/lib/src/x86_calcbonds.cpp
+++ b/src/lib/src/x86_calcbonds.cpp
@@ -36,12 +36,12 @@ void CalcBondsInner(const VectorToScalarT<VectorT> *coords0,
                     const VectorToScalarT<VectorT> *box, std::size_t n,
                     VectorToScalarT<VectorT> *out) {
   auto vecbox = BoxT(box);
-
+  auto c0 = VectorTriple<VectorT>();
+  auto c1 = VectorTriple<VectorT>();
   std::size_t i = 0;
   if (n % ValuesPerPack<VectorT>) {
-    auto c0 = VectorTriple<VectorT>(coords0);
-    auto c1 = VectorTriple<VectorT>(coords1);
-
+    c0.load(coords0);
+    c1.load(coords1);
     VectorT result = NewDistance3dWithBoundary(c0, c1, vecbox);
     // TODO constexpr if with CXX17 support
     if (streaming_store) {
@@ -52,8 +52,8 @@ void CalcBondsInner(const VectorToScalarT<VectorT> *coords0,
     i += n % ValuesPerPack<VectorT>;
   }
   for (; i < n; i += ValuesPerPack<VectorT>) {
-    auto c0 = VectorTriple<VectorT>(&coords0[3 * i]);
-    auto c1 = VectorTriple<VectorT>(&coords1[3 * i]);
+    c0.load(&coords0[3 * i]);
+    c1.load(&coords1[3 * i]);
 
     VectorT result = NewDistance3dWithBoundary(c0, c1, vecbox);
     // TODO constexpr if with CXX17 support

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -149,15 +149,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, ModifyFloats, float)
 (benchmark::State &state) { BM_AccessModifyRaw(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, ModifyFloats)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(10);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, ModifyDouble, double)
 (benchmark::State &state) { BM_AccessModifyRaw(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, ModifyDouble)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
                             VanillaCalcBondsOrthoInBoxFloat, float)
@@ -168,20 +168,20 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
 (benchmark::State &state) { BM_CalcBondsOrtho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, VanillaCalcBondsOrthoInBoxFloat)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, VanillaCalcBondsOrthoInBoxDouble)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat,
                             float)
 (benchmark::State &state) { BM_CalcBonds256Ortho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxFloat,
                             float)
@@ -192,12 +192,12 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxDouble,
 (benchmark::State &state) { BM_CalcBondsOrtho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxFloat)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxDouble)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxFloat,
                             float)
@@ -209,13 +209,13 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxDouble,
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxFloat)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {5, 5}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
+    ->RangeMultiplier(4);
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxDouble)
-    ->Ranges({{32, 32 << 5}, {0, 0}, {5, 5}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxFloat,
                             float)
@@ -226,12 +226,12 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble,
 (benchmark::State &state) { BM_CalcBondsOrtho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxFloat)
-    ->Ranges({{32, 32 << 5}, {32, 32 << 5}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble)
-    ->Ranges({{32, 32 << 5}, {32, 32 << 5}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {0, 0}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat,
                             float)
@@ -243,12 +243,12 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat)
-    ->Ranges({{32, 32 << 5}, {32, 32 << 5}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {5, 5}})
+    ->RangeMultiplier(4);
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxDouble)
-    ->Ranges({{32, 32 << 5}, {32, 32 << 5}, {0, 0}})
-    ->RangeMultiplier(2);
+    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {5, 5}})
+    ->RangeMultiplier(4);
 
 BENCHMARK_MAIN();

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -1,6 +1,6 @@
+#include "arch_config.h"
 #include "arrops.h"
 #include "distopia_better_distances.h"
-#include "arch_config.h"
 #include "vanilla.h"
 #include <benchmark/benchmark.h>
 #include <iostream>
@@ -86,9 +86,7 @@ public:
 
   void BM_CalcBondsOrtho(benchmark::State &state) {
     for (auto _ : state) {
-      for (std::size_t i = 0; i < nresults; i++) {
-        CalcBondsOrtho(coords0, coords1, box, nresults, results);
-      }
+      CalcBondsOrtho(coords0, coords1, box, nresults, results);
     }
     state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
@@ -98,10 +96,9 @@ public:
 
   void BM_VanillaCalcBondsOrtho(benchmark::State &state) {
     for (auto _ : state) {
-      for (std::size_t i = 0; i < nresults; i++) {
-        VanillaCalcBonds(coords0, coords1, box, nresults, results);
-      }
+      VanillaCalcBonds(coords0, coords1, box, nresults, results);
     }
+
     state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nresults * state.iterations(),
@@ -110,10 +107,9 @@ public:
 
   void BM_CalcBonds256Ortho(benchmark::State &state) {
     for (auto _ : state) {
-      for (std::size_t i = 0; i < nresults; i++) {
-        CalcBonds256(coords0, coords1, box, nresults, results);
-      }
+      CalcBonds256(coords0, coords1, box, nresults, results);
     }
+
     state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nresults * state.iterations(),
@@ -122,10 +118,9 @@ public:
 
   void BM_CalcBondsIdxOrtho(benchmark::State &state) {
     for (auto _ : state) {
-      for (std::size_t i = 0; i < nresults; i++) {
-        CalcBondsIdxOrtho(coords0, idxs, box, nindicies, results);
-      }
+      CalcBondsIdxOrtho(coords0, idxs, box, nindicies, results);
     }
+
     state.SetItemsProcessed(nindicies * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nindicies * state.iterations(),
@@ -176,7 +171,7 @@ BENCHMARK_REGISTER_F(CoordinatesDynamicMem, VanillaCalcBondsOrthoInBoxDouble)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
-#ifdef DISTOPIA_X86_AVX 
+#ifdef DISTOPIA_X86_AVX
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat,
                             float)
 (benchmark::State &state) { BM_CalcBonds256Ortho(state); }

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -1,13 +1,17 @@
+#include "arrops.h"
 #include <benchmark/benchmark.h>
 #include <iostream>
 #include <random>
 
+#define BOXSIZE 30
+
+// creates nrandom floating points between 0 and limit
 template <typename T>
-void RandomFloatingPoint(T *target, const std::size_t nrandom) {
-  std::random_device
-      rd; // Will be used to obtain a seed for the random number engine
-  std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
-  std::uniform_real_distribution<T> distribution(-10000, 10000);
+void RandomFloatingPoint(T *target, const int nrandom, const int neglimit,
+                         const int poslimit) {
+  std::random_device rd;
+  std::mt19937 gen(rd()); // Standard mersenne_twister_engine
+  std::uniform_real_distribution<T> distribution(neglimit, poslimit);
   for (size_t i = 0; i < nrandom; i++) {
     target[i] = distribution(gen);
   }
@@ -15,49 +19,182 @@ void RandomFloatingPoint(T *target, const std::size_t nrandom) {
 
 template <typename T> class CoordinatesDynamicMem : public benchmark::Fixture {
 public:
-  CoordinatesDynamicMem() : ncoords(0), coords(nullptr) {}
-
   void SetUp(benchmark::State &state) override {
     ncoords = static_cast<std::size_t>(state.range(0));
-    InitCoords();
-  }
-  void InitCoords() {
-    coords = new T[ncoords];
-    RandomFloatingPoint<T>(coords, ncoords);
-  }
 
-  void TearDown(benchmark::State &state) override {
-    if (coords) {
-      std::free(coords);
+    InitCoords(state.range(0), state.range(1), BOXSIZE, state.range(1));
+  }
+  // coordinates range from 0 - delta to BOXSIZE + delta
+  void InitCoords(const int n_results, const int n_indicies,
+                  const double boxsize, const double delta) {
+
+    nresults = n_results;
+    ncoords = 3 * nresults;
+    nindicies = n_indicies;
+
+    coords0 = new T[ncoords];
+    coords1 = new T[ncoords];
+    ref = new T[nresults];
+    results = new T[nresults];
+    idxs = new std::size_t[nindicies];
+
+    RandomFloatingPoint<T>(coords0, ncoords, 0 - delta, boxsize + delta);
+    RandomFloatingPoint<T>(coords1, ncoords, 0 - delta, boxsize + delta);
+
+    box[0] = boxsize;
+    box[1] = boxsize;
+    box[2] = boxsize;
+
+    for (size_t i = 0; i < nindicies; i++) {
+      idxs[i] = i;
     }
   }
 
-  void BMAccessModify(benchmark::State &state) {
-    for (auto _ : state) {
-      for (std::size_t i = 0; i < ncoords; i++) {
-        coords[i] += 1.0;
-      }
+  void TearDown(const ::benchmark::State &state) override {
+    if (coords0) {
+      delete[] coords0;
     }
-    state.SetBytesProcessed(T(state.iterations()) * T(state.range(0)));
+    if (coords1) {
+      delete[] coords1;
+    }
+    if (ref) {
+      delete[] ref;
+    }
+
+    if (results) {
+      delete[] results;
+    }
+
+    if (idxs) {
+      delete[] idxs;
+    }
   }
 
   // members
-  std::size_t ncoords;
-  T *coords;
+  int ncoords;
+  int nresults;
+  int nindicies;
+  T *coords0 = nullptr;
+  T *coords1 = nullptr;
+  T *ref = nullptr;
+  T *results = nullptr;
+  T box[3];
+  std::size_t *idxs = nullptr;
+
+  void BM_CalcBondsOrtho(benchmark::State &state) {
+    for (auto _ : state) {
+      for (std::size_t i = 0; i < nresults; i++) {
+        CalcBondsOrtho(coords0, coords1, box, nresults, results);
+      }
+    }
+    state.SetItemsProcessed(nresults * state.iterations());
+    state.counters["Per Result"] = benchmark::Counter(nresults * state.iterations(), benchmark::Counter::kIsRate | benchmark::Counter::kInvert );
+  }
+
+  void BM_CalcBondsIdxOrtho(benchmark::State &state) {
+    for (auto _ : state) {
+      for (std::size_t i = 0; i < nresults; i++) {
+        CalcBondsIdxOrtho(coords0, idxs, box, nindicies, results);
+      }
+    }
+    state.SetItemsProcessed(nindicies * state.iterations());
+    state.counters["Per Result"] = benchmark::Counter(nindicies * state.iterations(), benchmark::Counter::kIsRate | benchmark::Counter::kInvert );
+
+  }
+
+  void BM_AccessModifyRaw(benchmark::State &state) {
+    for (auto _ : state) {
+      std::size_t i;
+      for (i = 0; i < ncoords; ++i) {
+        coords0[i] += 1.0;
+      }
+    }
+    state.SetItemsProcessed(ncoords * state.iterations());
+    state.counters["Per Result"] = benchmark::Counter(ncoords*state.iterations(), benchmark::Counter::kIsRate | benchmark::Counter::kInvert );
+
+  }
 };
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, ModifyFloats, float)
-(benchmark::State &state) { BMAccessModify(state); }
+(benchmark::State &state) { BM_AccessModifyRaw(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, ModifyFloats)
-    ->RangeMultiplier(4)
-    ->Range(16, 16 << 12);
+    ->Ranges({{64, 64 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(2);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, ModifyDouble, double)
-(benchmark::State &state) { BMAccessModify(state); }
+(benchmark::State &state) { BM_AccessModifyRaw(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, ModifyDouble)
-    ->RangeMultiplier(4)
-    ->Range(16, 16 << 12);
+    ->Ranges({{64, 64 << 12}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxFloat,
+                            float)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxDouble,
+                            double)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxFloat)
+    ->Ranges({{64, 64 << 10}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxDouble)
+    ->Ranges({{64, 64 << 10}, {0, 0}, {0, 0}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxFloat,
+                            float)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxDouble,
+                            double)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+// coords can be +- 5 over boxlength
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxFloat)
+    ->Ranges({{64, 64 << 10}, {0, 0}, {5, 5}})
+    ->RangeMultiplier(2);
+
+// coords can be +- 5 over boxlength
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsOrthoOutBoxDouble)
+    ->Ranges({{64, 64 << 10}, {0, 0}, {5, 5}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxFloat,
+                            float)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble,
+                            double)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxFloat)
+    ->Ranges({{64, 64 << 10}, {32, 32 << 4}, {0, 0}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble)
+    ->Ranges({{64, 64 << 10}, {32, 32 << 4}, {0, 0}})
+    ->RangeMultiplier(2);
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat,
+                            float)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
+                            CalcBondsIdxOrthoOutBoxDouble, double)
+(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+
+// coords can be +- 5 over boxlength
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat)
+    ->Ranges({{64, 64 << 10}, {32, 32 << 4}, {0, 0}})
+    ->RangeMultiplier(2);
+
+// coords can be +- 5 over boxlength
+BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxDouble)
+    ->Ranges({{64, 64 << 10}, {32, 32 << 4}, {0, 0}})
+    ->RangeMultiplier(2);
 
 BENCHMARK_MAIN();

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -129,7 +129,7 @@ public:
     for (auto _ : state) {
       CalcBondsIdxOrtho(coords0, idxs, box, nidx_results, results);
     }
-    state.SetItemsProcessed(nindicies * state.iterations());
+    state.SetItemsProcessed(nidx_results * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nidx_results * state.iterations(),
         benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
@@ -139,7 +139,7 @@ public:
     for (auto _ : state) {
       VanillaCalcBondsIdx<T>(coords0, idxs, box, nidx_results, results);
     }
-    state.SetItemsProcessed(nindicies * state.iterations());
+    state.SetItemsProcessed(nidx_results * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nidx_results * state.iterations(),
         benchmark::Counter::kIsRate | benchmark::Counter::kInvert);

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -1,5 +1,6 @@
 #include "arrops.h"
 #include "distopia_better_distances.h"
+#include "arch_config.h"
 #include "vanilla.h"
 #include <benchmark/benchmark.h>
 #include <iostream>
@@ -175,6 +176,7 @@ BENCHMARK_REGISTER_F(CoordinatesDynamicMem, VanillaCalcBondsOrthoInBoxDouble)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
+#ifdef DISTOPIA_X86_AVX 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat,
                             float)
 (benchmark::State &state) { BM_CalcBonds256Ortho(state); }
@@ -182,6 +184,7 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat,
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBonds256OrthoInBoxFloat)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
+#endif
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsOrthoInBoxFloat,
                             float)

--- a/src/lib/tests/benchmark.cpp
+++ b/src/lib/tests/benchmark.cpp
@@ -109,7 +109,6 @@ public:
     for (auto _ : state) {
       CalcBonds256(coords0, coords1, box, nresults, results);
     }
-
     state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
         nresults * state.iterations(),
@@ -157,11 +156,11 @@ BENCHMARK_REGISTER_F(CoordinatesDynamicMem, ModifyDouble)
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
                             VanillaCalcBondsOrthoInBoxFloat, float)
-(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+(benchmark::State &state) { BM_VanillaCalcBondsOrtho(state); }
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
                             VanillaCalcBondsOrthoInBoxDouble, double)
-(benchmark::State &state) { BM_CalcBondsOrtho(state); }
+(benchmark::State &state) { BM_VanillaCalcBondsOrtho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, VanillaCalcBondsOrthoInBoxFloat)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
@@ -224,11 +223,11 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble,
 (benchmark::State &state) { BM_CalcBondsOrtho(state); }
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxFloat)
-    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {0, 0}})
+    ->Ranges({{128, 16 << 12}, {16, 16 << 4}, {0, 0}})
     ->RangeMultiplier(4);
 
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoInBoxDouble)
-    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {0, 0}})
+    ->Ranges({{128, 16 << 12}, {16, 16 << 4}, {0, 0}})
     ->RangeMultiplier(4);
 
 BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat,
@@ -241,12 +240,12 @@ BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesDynamicMem,
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxFloat)
-    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {5, 5}})
+    ->Ranges({{128, 16 << 12}, {16, 16 << 4}, {5, 5}})
     ->RangeMultiplier(4);
 
 // coords can be +- 5 over boxlength
 BENCHMARK_REGISTER_F(CoordinatesDynamicMem, CalcBondsIdxOrthoOutBoxDouble)
-    ->Ranges({{16, 16 << 12}, {16, 16 << 12}, {5, 5}})
+    ->Ranges({{128, 16 << 12}, {16, 16 << 4}, {5, 5}})
     ->RangeMultiplier(4);
 
 BENCHMARK_MAIN();

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -14,6 +14,8 @@
 #include "distopia.h"                  // a fancy approach
 #include "distopia_better_distances.h" // Jakub's fancy approach
 #include "vanilla.h"                   // a naive approach
+#include "arch_config.h"
+
 
 bool loadHeader(FILE *fp, int *Ncoords, float *box) {
   // header format:
@@ -201,7 +203,7 @@ int main(int argc, char *argv[]) {
     if (!verify(ref_results, results, nresults_bonds))
       printf("FMA result wrong!\n");
 
-#if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#ifdef DISTOPIA_X86_AVX 
     // YMM based function
     t1 = std::chrono::steady_clock::now();
     CalcBonds256(coords1, coords2, box, nresults_bonds, results);
@@ -323,7 +325,7 @@ int main(int argc, char *argv[]) {
       timings(nint_calc_bonds, niters, nresults_bonds, "NINT", timings_f);
   auto fma = timings(fma_calc_bonds, niters, nresults_bonds, "FMA", timings_f);
   
-#if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#ifdef DISTOPIA_X86_AVX 
   auto ymm = timings(ymm_calc_bonds, niters, nresults_bonds, "YMM", timings_f);
   auto cb = timings(cb_calc_bonds, niters, nresults_bonds, "CB", timings_f);
 
@@ -341,7 +343,7 @@ int main(int argc, char *argv[]) {
   printf("Nint speedup relative to vanilla   %f \n", nint_scaled);
   float fma_scaled = std::get<0>(vanilla) / std::get<0>(fma);
   printf("FMA speedup relative to vanilla    %f \n", fma_scaled);
-#if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
+#ifdef DISTOPIA_X86_AVX 
   float ymm_scaled = std::get<0>(vanilla) / std::get<0>(ymm);
   printf("YMM speedup relative to vanilla    %f \n", ymm_scaled);
   float cb_scaled = std::get<0>(vanilla) / std::get<0>(cb);

--- a/src/lib/tests/timings.cpp
+++ b/src/lib/tests/timings.cpp
@@ -142,6 +142,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::chrono::duration<double>> nint_calc_bonds;
   std::vector<std::chrono::duration<double>> fma_calc_bonds;
   std::vector<std::chrono::duration<double>> ymm_calc_bonds;
+  std::vector<std::chrono::duration<double>> cb_calc_bonds;
 
   for (size_t i = 0; i < niters; i++) {
 
@@ -209,6 +210,17 @@ int main(int argc, char *argv[]) {
     ymm_calc_bonds.push_back(dt);
     if (!verify(ref_results, results, nresults_bonds))
       printf("YMM result wrong!\n");
+
+    
+    // YMM based function
+    t1 = std::chrono::steady_clock::now();
+    CalcBondsOrtho(coords1, coords2, box, nresults_bonds, results);
+    t2 = std::chrono::steady_clock::now();
+    dt = (t2 - t1);
+    cb_calc_bonds.push_back(dt);
+    if (!verify(ref_results, results, nresults_bonds))
+      printf("CB result wrong!\n");
+
 #endif // #if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2 
 
     // ANGLES
@@ -310,8 +322,11 @@ int main(int argc, char *argv[]) {
   auto nint =
       timings(nint_calc_bonds, niters, nresults_bonds, "NINT", timings_f);
   auto fma = timings(fma_calc_bonds, niters, nresults_bonds, "FMA", timings_f);
+  
 #if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
   auto ymm = timings(ymm_calc_bonds, niters, nresults_bonds, "YMM", timings_f);
+  auto cb = timings(cb_calc_bonds, niters, nresults_bonds, "CB", timings_f);
+
 #endif
   timings_f.close();
 
@@ -329,6 +344,8 @@ int main(int argc, char *argv[]) {
 #if DISTOPIA_USE_AVX || DISTOPIA_USE_AVX2
   float ymm_scaled = std::get<0>(vanilla) / std::get<0>(ymm);
   printf("YMM speedup relative to vanilla    %f \n", ymm_scaled);
+  float cb_scaled = std::get<0>(vanilla) / std::get<0>(cb);
+  printf("CB speedup relative to vanilla    %f \n", cb_scaled);
 #endif
 
   return 0;


### PR DESCRIPTION
I have added a whole bunch of benchmark code. Im not sure if what the deal is with the timings themselves I need to dig in a bit further. It seems we are not getting that much of a speedup compared to what we thought we might be getting with `timings` but we shall see?  

EDIT:
~~Current googlebench results say that our best function (CalcBonds256) is 2x faster than vanilla, bu our other timing sheet says ~ 12x.~~ 

~~Similarly, googlebench says CalcBondsOrtho is about the same speed as vanilla (unlikely) while other timings say 8x faster.~~

~~I think we may be timing wrong in one or the other?~~


FIXED: It looks like we are getting great performance! I just did something stupid with the benchmarking.
