### PR TITLE
Include limits in googlebench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 docs/doxygen_build
 docs/_build
 .idea/
+.vscode/

--- a/src/lib/tests/googlebench/src/benchmark_register.h
+++ b/src/lib/tests/googlebench/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
On macOS, compilation fails with the following error:

```bash
CC=gcc-12 CXX=g++-12 cmake .. -DCMAKE_BUILD_TYPE=Release -DDISTOPIA_SELECT_SIMD=ON
```

```
In file included from /Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.cc:15:
/Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.h: In function 'typename std::vector<T>::iterator benchmark::internal::AddPowers(std::vector<T>*, T, T, int)':
/Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.h:22:30: error: 'numeric_limits' is not a member of 'std'
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                              ^~~~~~~~~~~~~~
/Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.h:22:46: error: expected primary-expression before '>' token
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                                              ^
/Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.h:22:49: error: '::max' has not been declared; did you mean 'std::max'?
   22 |   static const T kmax = std::numeric_limits<T>::max();
      |                                                 ^~~
      |                                                 std::max
In file included from /usr/local/Cellar/gcc/12.1.0/include/c++/12/algorithm:61,
                 from /Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/include/benchmark/benchmark.h:172,
                 from /Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/internal_macros.h:4,
                 from /Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/check.h:8,
                 from /Users/rmeli/Documents/git/software/distopia/src/lib/tests/googlebench/src/benchmark_register.h:6:
/usr/local/Cellar/gcc/12.1.0/include/c++/12/bits/stl_algo.h:5756:5: note: 'std::max' declared here
 5756 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
```

This PR fixes the issue by including `limits` explicitly.

---

OS: macOS 12.5.1
GCC: gcc-12 (Homebrew GCC 12.1.0) 12.1.0