### PR TITLE
Set numpy build requirements, drop py3.7

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,6 +101,8 @@ jobs:
         python -m pip list
 
     - name: build
+      env:
+        SETUPTOOLS_ENABLE_FEATURES: legacy-editable
       run: pip install -e . 
         # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -110,9 +110,7 @@ jobs:
       run: |
         # https://github.com/scikit-build/scikit-build/issues/740
         export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-        # python -m pip install -e . --  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
         python -m pip install .
-        # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 
     - name: test
       run: ctest --test-dir _skbuild/*/cmake-build/libdistopia

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -97,9 +97,9 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - uses: BSFishy/pip-action@v1
-      with:
-        requirements: requirements.txt
+        #- uses: BSFishy/pip-action@v1
+        #  with:
+        #    requirements: requirements.txt
 
     - name: check_env
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,7 +101,6 @@ jobs:
         python -m pip list
 
     - name: build
-      env:
       run: |
         # https://github.com/scikit-build/scikit-build/issues/740
         export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -110,7 +110,8 @@ jobs:
       run: |
         # https://github.com/scikit-build/scikit-build/issues/740
         export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-        pip install -e . --  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+        # python -m pip install -e . --  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+        python -m pip install .
         # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 
     - name: test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11-rc.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
         include:
           - os: macos-latest
             cxx_compiler: "clang++"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - uses: BSFishy/pip-action@v1
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -97,9 +97,10 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-        #- uses: BSFishy/pip-action@v1
-        #  with:
-        #    requirements: requirements.txt
+    - uses: BSFishy/pip-action@v1
+      if: ${{ matrix.os }} == "windows-latest"
+      with:
+        requirements: requirements.txt
 
     - name: check_env
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,12 @@
 name: CMake
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -110,7 +110,7 @@ jobs:
       run: |
         # https://github.com/scikit-build/scikit-build/issues/740
         export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-        pip install -e . 
+        pip install -e . --  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
         # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 
     - name: test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,6 @@ jobs:
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
         include:
           - os: macos-latest
             cxx_compiler: "clang++"
@@ -54,24 +53,53 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.10
 
     - uses: BSFishy/pip-action@v1
       with:
         requirements: requirements.txt
 
-
     - name: check_env
       run: |
         which python
-        which python3
         python -m pip list
 
     - name: Build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: python3 setup.py build -- ${{ matrix.instruction_set_flag }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
+      run: python setup.py build -- ${{ matrix.instruction_set_flag }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
 
     - name: Test
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run:  ctest --test-dir _skbuild/*/cmake-build/libdistopia
+
+  python-matrix:
+    # specifically aims to 
+    runs-on: ${{ matrix.os }}
+    strategy:
+      os: [ubuntu-latest, macos-latest, windows-latest]
+      python: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+
+    - uses: BSFishy/pip-action@v1
+      with:
+        requirements: requirements.txt
+
+    - name: check_env
+      run: |
+        which python
+        python -m pip list
+
+    - name: build
+      run: pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
+
+    - name: test
+      run: ctest --test-dir _skbuild/*/cmake-build/libdistopia

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,14 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.worfklow }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally
@@ -52,13 +60,17 @@ jobs:
       with:
         requirements: requirements.txt
 
+
+    - name: check_env
+      run: |
+        which python
+        python -m pip list
+
     - name: Build
-      shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: python3 setup.py build -- ${{ matrix.instruction_set_flag }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
 
     - name: Test
-      shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run:  ctest --test-dir _skbuild/*/cmake-build/libdistopia

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,6 +64,7 @@ jobs:
     - name: check_env
       run: |
         which python
+        which python3
         python -m pip list
 
     - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: '3.10'
 
     - uses: BSFishy/pip-action@v1
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,8 +77,10 @@ jobs:
     # specifically aims to 
     runs-on: ${{ matrix.os }}
     strategy:
-      os: [ubuntu-latest, macos-latest, windows-latest]
-      python: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,7 +101,8 @@ jobs:
         python -m pip list
 
     - name: build
-      run: pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
+      run: pip install -e . 
+        # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 
     - name: test
       run: ctest --test-dir _skbuild/*/cmake-build/libdistopia

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -102,8 +102,10 @@ jobs:
 
     - name: build
       env:
-        SETUPTOOLS_ENABLE_FEATURES: legacy-editable
-      run: pip install -e . 
+      run: |
+        # https://github.com/scikit-build/scikit-build/issues/740
+        export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
+        pip install -e . 
         # pip install -e . -DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON
 
     - name: test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,8 @@ jobs:
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON"]
-        os: [ubuntu-latest, macos-latest, windows-latest] 
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11-rc.2"]
         include:
           - os: macos-latest
             cxx_compiler: "clang++"
@@ -42,9 +43,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
+
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
+
     - uses: BSFishy/pip-action@v1
       with:
         requirements: requirements.txt

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,13 +79,14 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run:  ctest --test-dir _skbuild/*/cmake-build/libdistopia
 
-  python-matrix:
-    # specifically aims to 
+  pip-install:
+    # A pure Python install, which relies purely on pyproject.toml contents
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # for now windows pip install builds seem to fail for some reason
+        os: [ubuntu-latest, macos-latest,]
         python: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
 
     steps:
@@ -97,21 +98,13 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    - uses: BSFishy/pip-action@v1
-      if: ${{ matrix.os }} == "windows-latest"
-      with:
-        requirements: requirements.txt
-
     - name: check_env
       run: |
         which python
         python -m pip list
 
     - name: build
-      run: |
-        # https://github.com/scikit-build/scikit-build/issues/740
-        export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-        python -m pip install .
+      run: python -m pip install .
 
     - name: test
       run: ctest --test-dir _skbuild/*/cmake-build/libdistopia

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,15 @@ requires = [
   # declaring numpy versions specifically to x86_64
   # lowest NumPy we can use for a given Python,
   # except for more exotic platform (Mac Arm flavors)
-  "numpy==1.20.0; python_version=='3.8' and platform_machine=='x86_64'",
-  "numpy==1.20.0; python_version=='3.9' and platform_machine=='x86_64'",
+  # Also don't allow PyPy builds
+  "numpy==1.20.0; python_version=='3.8' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
+  "numpy==1.20.0; python_version=='3.9' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
   # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
   # safest to build at 1.21.6 for all platforms
   "numpy==1.21.6; python_version=='3.10' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
   "numpy==1.23.2; python_version=='3.11' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
+  # default to just numpy for unknown versions of Python
+  "numpy; python_version>='3.12'",
   "scikit-build",
   "cmake",
   "cython>=0.28,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,21 @@
 requires = [
   "setuptools>=42",
   "wheel",
-  "numpy",
+  # lowest NumPy we can use for a given Python,
+  # except for more exotic platform (Mac Arm flavors)
+  # aarch64, AIX, s390x all support < 1.20 so we can safely pin to this
+  "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin')",
+  "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin')",
+  # arm64 on darwin for py3.8+ requires numpy >=1.21.0
+  "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
+  "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+  # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+  # safest to build at 1.21.6 for all platforms
+  "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
+  "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
   "scikit-build",
   "cmake",
-  "cython",
+  "cython>=0.28,<3.0",
   "versioneer-518",
   "ninja; platform_system!='Windows'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,12 @@
 [build-system]
 requires = [
+  "platform_machine=='x86_64'",
   "setuptools>=42",
   "wheel",
   # lowest NumPy we can use for a given Python,
   # except for more exotic platform (Mac Arm flavors)
-  # aarch64, AIX, s390x all support < 1.20 so we can safely pin to this
-  "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin')",
-  "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin')",
-  # arm64 on darwin for py3.8+ requires numpy >=1.21.0
-  "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-  "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
+  "numpy==1.20.0; python_version=='3.8'",
+  "numpy==1.20.0; python_version=='3.9'",
   # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
   # safest to build at 1.21.6 for all platforms
   "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [build-system]
 requires = [
-  "platform_machine=='x86_64'",
+  #"platform_machine=='x86_64'",
   "setuptools>=42",
   "wheel",
   # lowest NumPy we can use for a given Python,
   # except for more exotic platform (Mac Arm flavors)
-  "numpy==1.20.0; python_version=='3.8'",
-  "numpy==1.20.0; python_version=='3.9'",
+  "numpy==1.20.0; python_version=='3.8' and platform_machine=='x86_64'",
+  "numpy==1.20.0; python_version=='3.9' and platform_machine=='x86_64'",
   # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
   # safest to build at 1.21.6 for all platforms
-  "numpy==1.21.6; python_version=='3.10' and platform_python_implementation != 'PyPy'",
-  "numpy==1.23.2; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+  "numpy==1.21.6; python_version=='3.10' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
+  "numpy==1.23.2; python_version=='3.11' and platform_machine=='x86_64' and platform_python_implementation != 'PyPy'",
   "scikit-build",
   "cmake",
   "cython>=0.28,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
 requires = [
-  #"platform_machine=='x86_64'",
   "setuptools>=42",
   "wheel",
+  # declaring numpy versions specifically to x86_64
   # lowest NumPy we can use for a given Python,
   # except for more exotic platform (Mac Arm flavors)
-  "numpy==1.20.0; python_version=='3.8' and platform_machine=='x86_64'",
+  "numpy==1.20.0; python_version=='3.8' and (platform_machine=='x86_64' or platform_machine=='amd64')",
   "numpy==1.20.0; python_version=='3.9' and platform_machine=='x86_64'",
   # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
   # safest to build at 1.21.6 for all platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   # declaring numpy versions specifically to x86_64
   # lowest NumPy we can use for a given Python,
   # except for more exotic platform (Mac Arm flavors)
-  "numpy==1.20.0; python_version=='3.8' and (platform_machine=='x86_64' or platform_machine=='amd64')",
+  "numpy==1.20.0; python_version=='3.8' and platform_machine=='x86_64'",
   "numpy==1.20.0; python_version=='3.9' and platform_machine=='x86_64'",
   # As per https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
   # safest to build at 1.21.6 for all platforms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cmake 
-cython
-numpy
+cython>=0.28.0,<3.0.0
+numpy>=1.20.0
 ninja
 scikit-build

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author=['Hugo MacDermott-Opeskin', "Richard Gowers"],
     license="MIT",
     packages=['distopia'],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     keywords=(
         "molecular dynamics distances simulation SIMD"
     ),
@@ -20,7 +20,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: C++",
         "Programming Language :: Cython",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
         "Issue Tracker": "https://github.com/MDAnalysis/distopia/issues",
     },
     install_requires=[
-        "numpy",
-        "cython",
+        "numpy>=1.20.0",
+        "cython>=0.28.0,<3.0.0",
         "scikit-build",
         "cmake"
     ],


### PR DESCRIPTION
Follow-up from discord discussion.

1. I'm setting the numpy build versions, this is very important if you want to avoid ABI issues.
2. I also **strongly** recommend dropping python 3.7

TODO:
  - [x] update CI to loop over Python versions & os versions
  - [x] add in a check for py3.11rc2