### PR TITLE
Avoid osx-arm64 macos-14 runners in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,9 +40,9 @@ jobs:
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON",
                               "-DDISTOPIA_DISPATCH=ON -DDISTOPIA_DISPATCH_MANUAL=ON -DDISTOPIA_USE_SSE3=ON -DDISTOPIA_USE_SSE4_1=ON -DDISTOPIA_USE_AVX=ON -DDISTOPIA_BUILD_TEST=ON"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         include:
-          - os: macos-latest
+          - os: macos-13
             cxx_compiler: "clang++"
             c_compiler: "clang"
           - os: ubuntu-latest
@@ -51,10 +51,10 @@ jobs:
           - os: windows-latest
             cxx_compiler: "cl"
             c_compiler: "cl"
-        exclude:
+        # exclude:
         # excludes AVX2 on macOS as the VM doesn't seem to support some AVX2 instructions.
-          - os: macos-latest
-            instruction_set_flag: "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON"
+        #  - os: macos-13
+        #    instruction_set_flag: "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON"
 
     steps:
     - uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         # for now windows pip install builds seem to fail for some reason
-        os: [ubuntu-latest, macos-latest,]
+        os: [ubuntu-latest, macos-13,]
         python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,10 +51,6 @@ jobs:
           - os: windows-latest
             cxx_compiler: "cl"
             c_compiler: "cl"
-        # exclude:
-        # excludes AVX2 on macOS as the VM doesn't seem to support some AVX2 instructions.
-        #  - os: macos-13
-        #    instruction_set_flag: "-DDISTOPIA_MANUAL_SELECT_SIMD=ON -DDISTOPIA_USE_AVX2=ON -DDISTOPIA_BUILD_TEST=ON"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
macos-14 is osx-arm64 arch and ass far as I understand the current release of distopia doesn't support this